### PR TITLE
Tox.ini to help avoid silly mistakes

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,9 +3,12 @@ from __future__ import unicode_literals
 import mock
 import requests
 import requests_oauthlib
-import StringIO
 import unittest
 
+try:
+    import StringIO
+except ImportError:
+    from io import StringIO
 
 @mock.patch('oauthlib.oauth1.rfc5849.generate_timestamp')
 @mock.patch('oauthlib.oauth1.rfc5849.generate_nonce')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26,py27,py31,py32,py33
+[testenv]
+deps=nose
+     requests
+     oauthlib
+     mock
+commands=nosetests


### PR DESCRIPTION
Note, these will fail until requests pushes the prepare_auth / prepare_body swap to pypi. They will catch errors like StringIO and unicode however...
