### PR TITLE
require at least version 0.3.4 of oauthlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-oauthlib
+oauthlib>=0.3.4

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ settings.update(
     author_email='me@kennethreitz.com',
     url='https://github.com/requests/requests-oauthlib',
     packages= ['requests_oauthlib',],
-    install_requires=['oauthlib'],
+    install_requires=['oauthlib>=0.3.4'],
     license='ISC',
     classifiers=(
         # 'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Hi,

I tried to use requests (1.0.4) & requests-oauthlib (master version) and faild on my Ubuntu 12.10 system.

After a bit of investigation I found that the python-oauthlib package is of version 0.3.0 while requests-oauthlib imports certain things from oauthlib.oauth1 that only became available in version 0.3.4 of oauthlib.

The pull requests makes the dependency more explicit.
## 

Misha
