### PR TITLE
OAuth1 not working when using SIGNATURE_TYPE_BODY

### DIFF
--- a/requests_oauthlib/core.py
+++ b/requests_oauthlib/core.py
@@ -45,7 +45,7 @@ class OAuth1(object):
 
         if is_form_encoded or extract_params(r.body):
             r.headers['Content-Type'] = CONTENT_TYPE_FORM_URLENCODED
-            r.url, r.headers, r.data = self.client.sign(
+            r.url, r.headers, r.body = self.client.sign(
                 unicode(r.url), unicode(r.method), r.body or '', r.headers)
         else:
             # Omit body data in the signing of non form-encoded requests


### PR DESCRIPTION
If you use <code>oauthlib.oauth1.SIGNATURE_TYPE_BODY</code> as your OAuth signature type the plugin doesn't update the <code>req.body</code> value it instead keeps the 'new' body inside <code>req.data</code> which is then never merged with the  <code>req.body</code> and therefore the OAuth params are never transmitted. 

Directly replacing the <code>req.body</code> with the result of the sign request works here. requests.models.prepare_auth takes care of recalculating the 'Content-Length'-header.
