### PR TITLE
Fix OAuth2Session to work with Python3 and to function properly after a token refresh

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -180,6 +180,8 @@ class OAuth2Session(requests.Session):
                     token = self.refresh_token(self.auto_refresh_url)
                     if self.token_updater:
                         self.token_updater(token)
+                        url, headers, data = self._client.add_token(url,
+                                http_method=method, body=data, headers=headers)
                     else:
                         raise TokenUpdated(token)
                 else:


### PR DESCRIPTION
There may be some other places which need changes to work properly with Python3, but so far these are the things I've run into.
