### PR TITLE
The URL should always be native.

### DIFF
--- a/requests_oauthlib/core.py
+++ b/requests_oauthlib/core.py
@@ -10,6 +10,12 @@ import sys
 if sys.version > "3":
     unicode = str
 
+    def to_native_str(string):
+        return string.decode('utf-8')
+else:
+    def to_native_str(string):
+        return string
+
 # OBS!: Correct signing of requests are conditional on invoking OAuth1
 # as the last step of preparing a request, or at least having the
 # content-type set properly.
@@ -57,5 +63,7 @@ class OAuth1(object):
             # Omit body data in the signing of non form-encoded requests
             r.url, r.headers, _ = self.client.sign(
                 unicode(r.url), unicode(r.method), None, r.headers)
+
+        r.url = to_native_str(r.url)
 
         return r

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,3 +96,14 @@ class OAuth1Test(unittest.TestCase):
                               files={'media': (os.path.basename(f.name), f)},
                               auth=oauth)
             self.assertEqual(r.status_code, 200)
+
+    def test_url_is_native_str(self, generate_nonce, generate_timestamp):
+        """
+        Test that the URL is always a native string.
+        """
+        generate_nonce.return_value = 'abc'
+        generate_timestamp.return_value = '1'
+        oauth = requests_oauthlib.OAuth1('client_key')
+
+        r = requests.get('http://httpbin.org/get', auth=oauth)
+        self.assertTrue(isinstance(r.request.url, str))


### PR DESCRIPTION
This should resolve the issue that @michaelhelmick had in kennethreitz/requests#1366. In short, the keys for doing Transport Adapter lookups are native strings, but requests_oauthlib turns the URL into bytes. Not helpful. This prevents that behaviour while avoiding regressing kennethreitz/requests#1252.
