### PR TITLE
Use raw string syntax for client_id and client_secret

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Fetching a protected resource after obtaining an access token can be as simple a
 .. code-block:: pycon
 
     >>> from requests_oauthlib import OAuth2Session
-    >>> google = OAuth2Session('client_id', token='token')
+    >>> google = OAuth2Session(r'client_id', token=r'token')
     >>> url = 'https://www.googleapis.com/oauth2/v1/userinfo'
     >>> r = google.get(url)
 

--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -19,8 +19,8 @@ the provider is Google and the protected resource the user profile.
 
 .. code-block:: pycon
 
-    >>> client_id = 'your_client_id'
-    >>> client_secret = 'your_client_secret'
+    >>> client_id = r'your_client_id'
+    >>> client_secret = r'your_client_secret'
     >>> redirect_uri = 'https://your.callback/uri'
 
 1. User authorization through redirection. First we will create an
@@ -107,7 +107,7 @@ for ``expires_in`` or omit it entirely.
     ...     'token_type': 'Bearer',
     ...     'expires_in': '-30',     # initially 3600, need to be updated by you
     ...  }
-    >>> client_id = 'foo'
+    >>> client_id = r'foo'
     >>> refresh_url = 'https://provider.com/token'
     >>> protected_url = 'https://provider.com/secret'
 
@@ -115,7 +115,7 @@ for ``expires_in`` or omit it entirely.
     >>> # when refreshing tokens, usually for authentication purposes.
     >>> extra = {
     ...     'client_id': client_id,
-    ...     'client_secret': 'potato',
+    ...     'client_secret': r'potato',
     ... }
 
     >>> # After updating the token you will most likely want to save it.


### PR DESCRIPTION
Replaced client_id and client_secret literals in docs with raw strings to avoid problems described in issue @59
