### PR TITLE
Cleaned secure transport detection and fixed one missing case

### DIFF
--- a/requests_oauthlib/oauth2_auth.py
+++ b/requests_oauthlib/oauth2_auth.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
 
+from .utils import is_secure_transport
+
 
 class OAuth2(object):
     """Adds proof of authorization (OAuth2 token) to the request."""
@@ -27,7 +29,7 @@ class OAuth2(object):
         a token type that allows for plain HTTP in the future and then this
         should be updated to allow plain HTTP on a white list basis.
         """
-        if not r.url.startswith('https://'):
+        if not is_secure_transport(r.url):
             raise InsecureTransportError()
         r.url, r.headers, r.body = self._client.add_token(r.url,
                 http_method=r.method, body=r.body, headers=r.headers)

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -5,6 +5,8 @@ from oauthlib.common import log, generate_token, urldecode
 from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
 from oauthlib.oauth2 import TokenExpiredError
 
+from .utils import is_secure_transport
+
 
 class TokenUpdated(Warning):
     def __init__(self, token):
@@ -122,7 +124,7 @@ class OAuth2Session(requests.Session):
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict
         """
-        if 'DEBUG' not in os.environ and not token_url.startswith('https://'):
+        if not is_secure_transport(token_url):
             raise InsecureTransportError()
 
         if not code and authorization_response:
@@ -184,7 +186,7 @@ class OAuth2Session(requests.Session):
         if not token_url:
             raise ValueError('No token endpoint set for auto_refresh.')
 
-        if 'DEBUG' not in os.environ and not token_url.startswith('https://'):
+        if not is_secure_transport(token_url):
             raise InsecureTransportError()
 
         # Need to nullify token to prevent it from being added to the request
@@ -210,7 +212,7 @@ class OAuth2Session(requests.Session):
 
     def request(self, method, url, data=None, headers=None, **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
-        if 'DEBUG' not in os.environ and not url.startswith('https://'):
+        if not is_secure_transport(url):
             raise InsecureTransportError()
         if self.token:
             log.debug('Adding token %s to request.', self.token)

--- a/requests_oauthlib/utils.py
+++ b/requests_oauthlib/utils.py
@@ -1,0 +1,9 @@
+from __future__ import unicode_literals
+import os
+
+
+def is_secure_transport(uri):
+    """Check if the uri is over ssl."""
+    if os.environ.get('DEBUG'):
+        return True
+    return uri.lower().startswith('https://')


### PR DESCRIPTION
Using is_secure_transport from oauthlib do the checks for https being required, with DEBUG in env skipping the check. is_secure_transport is in its own file as in oauthlib it is an internal function. There was one case where DEBUG wasn't checked yet in requests-oauthlib, this addresses this too.
