### PR TITLE
Fix KeyError in facebook_compliance_fix

### DIFF
--- a/requests_oauthlib/compliance_fixes/facebook.py
+++ b/requests_oauthlib/compliance_fixes/facebook.py
@@ -6,7 +6,9 @@ def facebook_compliance_fix(session):
 
     def _compliance_fix(r):
         token = dict(urldecode(r.text))
-        token['expires_in'] = token['expires']
+        expires = token.get('expires')
+        if expires is not None:
+            token['expires_in'] = expires
         token['token_type'] = 'Bearer'
         r._content = dumps(token)
         return r


### PR DESCRIPTION
Facebook does not always send an expiration value in an access token response. When the expiration is not included, a KeyError results. Instead, only attempt to set 'expires_in' if the 'expires' key is included in the response.
