### PR TITLE
Prevent duplicate headers in OAuth1 by ensuring r.headers are native string. Fix #73.

### DIFF
--- a/requests_oauthlib/core.py
+++ b/requests_oauthlib/core.py
@@ -66,6 +66,11 @@ class OAuth1(object):
             r.url, headers, _ = self.client.sign(
                 unicode(r.url), unicode(r.method), None, r.headers)
 
-        r.headers.update(headers)
+
+        headers = dict((to_native_str(k), to_native_str(v))
+                       for k, v in headers.items())
+        # Replace rather than update to avoid duplicates due to different
+        # string types, bytes and unicode.
+        r.headers = r.headers.__class__(headers)
         r.url = to_native_str(r.url)
         return r

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -40,7 +40,7 @@ class OAuth1SessionTest(unittest.TestCase):
             return fake_send
 
         header = OAuth1Session('foo')
-        header.send = verify_signature(lambda r: r.headers['Authorization'.encode('utf-8')])
+        header.send = verify_signature(lambda r: r.headers['Authorization'])
         header.post('https://i.b')
 
         query = OAuth1Session('foo', signature_type=SIGNATURE_TYPE_QUERY)
@@ -160,7 +160,7 @@ class OAuth1SessionTest(unittest.TestCase):
 
     def verify_signature(self, signature):
         def fake_send(r, **kwargs):
-            auth_header = r.headers['Authorization'.encode('utf-8')]
+            auth_header = r.headers['Authorization']
             if isinstance(auth_header, bytes_type):
                 auth_header = auth_header.decode('utf-8')
             self.assertEqual(auth_header, signature)


### PR DESCRIPTION
@Lukasa what do you think about this header conversion? It's a bit of a hack replacing r.headers this way but using r.headers.update will result in duplicates (as in key b'A' != u'A', could not see this fixed in master or maybe it is expected behaviour?). 

Tested with current pip (py 2.6 - 3.3) and github master (py 3.3)  version of requests.

As a bonus we no longer need to encode header strings in py 3 (for OAuth1 at least). Only replaced the encoding locations which broke the test suite. Will look into the rest separately if we merge.
