### PR TITLE
Added fix for compliance fixes for Facebook and LinkedIn on Python 3

### DIFF
--- a/requests_oauthlib/compliance_fixes/facebook.py
+++ b/requests_oauthlib/compliance_fixes/facebook.py
@@ -1,6 +1,7 @@
 from json import dumps
 from oauthlib.common import urldecode
 
+import six
 
 def facebook_compliance_fix(session):
 
@@ -11,6 +12,12 @@ def facebook_compliance_fix(session):
             token['expires_in'] = expires
         token['token_type'] = 'Bearer'
         r._content = dumps(token)
+
+        # on Python 3 this may raise an exception, since requests' text
+        # property expects a bytes object instead of str.
+        if not isinstance(r._content, six.binary_type):
+            r._content = r._content.encode('utf-8')
+
         return r
 
     session.register_compliance_hook('access_token_response', _compliance_fix)

--- a/requests_oauthlib/compliance_fixes/linkedin.py
+++ b/requests_oauthlib/compliance_fixes/linkedin.py
@@ -2,6 +2,7 @@ from json import loads, dumps
 
 from oauthlib.common import add_params_to_uri
 
+import six
 
 def linkedin_compliance_fix(session):
 
@@ -9,6 +10,12 @@ def linkedin_compliance_fix(session):
         token = loads(r.text)
         token['token_type'] = 'Bearer'
         r._content = dumps(token)
+
+        # on Python 3 this may raise an exception, since requests' text
+        # property expects a bytes object instead of str.
+        if not isinstance(r._content, six.binary_type):
+            r._content = r._content.encode('utf-8')
+
         return r
 
     def _non_compliant_param_name(url, headers, data):


### PR DESCRIPTION
I'm having issues when using the latest requests-oauthlib with Facebook, because requests' text method expects the content portion to be a bytes object in Python 3. The solution to this issue was (at least for me) to encode the JSON dumped content appropriately.
