### PR TITLE
Fix spaces encoding in parameters

### DIFF
--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -158,6 +158,15 @@ class OAuth1SessionTest(unittest.TestCase):
             self.assertTrue(isinstance(k, unicode_type))
             self.assertTrue(isinstance(v, unicode_type))
 
+    def test_params_with_spaces(self):
+        class RequestIntercepter(OAuth1Session):
+            def send(self, request, **kwargs):
+                self.sent_url = request.url
+
+        auth = RequestIntercepter('foo')
+        auth.get('http://example.com/', params={'q': 'foo bar'})
+        self.assertEqual(str('http://example.com/?q=foo%20bar'), auth.sent_url)
+
     def verify_signature(self, signature):
         def fake_send(r, **kwargs):
             auth_header = r.headers['Authorization']


### PR DESCRIPTION
OAuth requires spaces to be encoded as %20 instead of + in order to generate a valid signature.

Explained in http://troy.yort.com/2-common-problems-with-oauth-client-libraries/

Before this patch, I was unable to use Yahoo!'s BOSS Placefinder API, which now seems to be responding correctly to me, instead of what it used to say:

```
<?xml version='1.0' encoding='UTF-8'?>
<yahoo:error xmlns:yahoo='http://yahooapis.com/v1/base.rng'
  xml:lang='en-US'>
  <yahoo:description>Please provide valid credentials. OAuth oauth_problem="signature_invalid", realm="yahooapis.com"</yahoo:description>
</yahoo:error>
```
