### PR TITLE
Fixes #99: Improve Facebook compatibility fix with content-type and status code checking, and parse_qsl instead oauthlib.common.urldecode.

### DIFF
--- a/requests_oauthlib/compliance_fixes/facebook.py
+++ b/requests_oauthlib/compliance_fixes/facebook.py
@@ -7,13 +7,13 @@ def facebook_compliance_fix(session):
 
     def _compliance_fix(r):
         # if Facebook claims to be sending us json, let's trust them.
-        if r.headers['content-type'] == 'application/json':
+        if 'application/json' in r.headers['content-type']:
             return r
 
         # Facebook returns a content-type of text/plain when sending their
         # x-www-form-urlencoded responses, along with a 200. If not, let's
         # assume we're getting JSON and bail on the fix.
-        if r.headers['content-type'] == 'text/plain' and r.status_code == 200:
+        if 'text/plain' in r.headers['content-type'] and r.status_code == 200:
             token = dict(parse_qsl(r.text, keep_blank_values=True))
         else:
             return r


### PR DESCRIPTION
Fixes #99.
