### PR TITLE
Fixed oauth2 workflow doc. A wrong argument name was being used in Web Application Flow

### DIFF
--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -85,7 +85,7 @@ the provider is Google and the protected resource is the user's profile.
             authorization_response=authorization_response,
             # Google specific extra parameter used for client
             # authentication
-            client_secret=secret)
+            client_secret=client_secret)
 
 3. Access protected resources using the access token you just obtained.
    For example, get the users profile info.


### PR DESCRIPTION
Application Flow.
- Fixed doc of oauth2 workflow.
- Web Application Flow defined a variable called `client_secret`.
- We intended to use `client_secret`, but were accidentally calling it
  `secret`. Changed `secret` to say `client_secret`.
