### PR TITLE
Depend on the pycrypto enabled oauthlib in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ settings.update(
     author_email='me@kennethreitz.com',
     url='https://github.com/requests/requests-oauthlib',
     packages=['requests_oauthlib', 'requests_oauthlib.compliance_fixes'],
-    install_requires=['oauthlib>=0.4.2', 'requests>=2.0.0'],
+    install_requires=['oauthlib[rsa]>=0.4.2', 'requests>=2.0.0'],
     license='ISC',
     classifiers=(
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
requests-oauthlib requires a pycrypto-enabled oauthlib. This is enabled in requirements.txt, but not when setup.py is called directly.
