### PR TITLE
Update tumblr.rst

### DIFF
--- a/docs/examples/tumblr.rst
+++ b/docs/examples/tumblr.rst
@@ -23,7 +23,7 @@ Enter a call back url (can just be http://www.tumblr.com/dashboard) and get the 
     >>> tumblr.fetch_request_token(request_token_url)
 
     >>> # Link user to authorization page
-    >>> authorization_url = tumblr.authorization_url(base_authorization_url)
+    >>> authorization_url = tumblr.authorization_url(authorization_base_url)
     >>> print 'Please go here and authorize,', authorization_url
 
     >>> # Get the verifier code from the URL


### PR DESCRIPTION
Fix error NameError: name 'base_authorization_url' is not defined

Change base_authorization_url to authorization_base_url as is defined in the OAuth URLs initialization. The names were changed erroneously
