### PR TITLE
Allow for request timeouts to be specified

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -112,7 +112,7 @@ class OAuth2Session(requests.Session):
 
     def fetch_token(self, token_url, code=None, authorization_response=None,
             body='', auth=None, username=None, password=None, method='POST',
-            verify=True, **kwargs):
+            timeout=None, verify=True, **kwargs):
         """Generic method for fetching an access token from the token endpoint.
 
         If you are using the MobileApplicationClient you will want to use
@@ -131,6 +131,7 @@ class OAuth2Session(requests.Session):
         :param method: The HTTP method used to make the request. Defaults
                        to POST, but may also be GET. Other methods should
                        be added as needed.
+        :param timeout: Timeout of the request in seconds.
         :param verify: Verify SSL certificate.
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict
@@ -156,13 +157,13 @@ class OAuth2Session(requests.Session):
         if method.upper() == 'POST':
             r = self.post(token_url, data=dict(urldecode(body)),
                 headers={'Accept': 'application/json'}, auth=auth,
-                verify=verify)
+                timeout=timeout, verify=verify)
             log.debug('Prepared fetch token request body %s', body)
         elif method.upper() == 'GET':
             # if method is not 'POST', switch body to querystring and GET
             r = self.get(token_url, params=dict(urldecode(body)),
                 headers={'Accept': 'application/json'}, auth=auth,
-                verify=verify)
+                timeout=timeout, verify=verify)
             log.debug('Prepared fetch token request querystring %s', body)
         else:
             raise ValueError('The method kwarg must be POST or GET.')
@@ -194,7 +195,7 @@ class OAuth2Session(requests.Session):
         return self.token
 
     def refresh_token(self, token_url, refresh_token=None, body='', auth=None,
-                      **kwargs):
+                      timeout=None, verify=True, **kwargs):
         """Fetch a new access token using a refresh token.
 
         :param token_url: The token endpoint, must be HTTPS.
@@ -202,6 +203,8 @@ class OAuth2Session(requests.Session):
         :param body: Optional application/x-www-form-urlencoded body to add the
                      include in the token request. Prefer kwargs over body.
         :param auth: An auth tuple or method as accepted by requests.
+        :param timeout: Timeout of the request in seconds.
+        :param verify: Verify SSL certificate.
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict
         """
@@ -221,7 +224,8 @@ class OAuth2Session(requests.Session):
         body = self._client.prepare_refresh_body(body=body,
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
-        r = self.post(token_url, data=dict(urldecode(body)), auth=auth)
+        r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
+                      timeout=timeout, verify=verify)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',


### PR DESCRIPTION
By default requests has no timeout, this is risky when using it from a server backend. Similar to the verify that got exposed recently, this adds a timeout parameter, which defaults to the requests default of None, to refresh_token and fetch_token.
