### PR TITLE
Fix issue of redundant oauth rebuilding when redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tox.ini
 .tox/
 
 .workon
+.*/
 
 t.py
 

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -328,7 +328,6 @@ class OAuth1Session(requests.Session):
         When being redirected we should always strip Authorization
         header, since nonce may not be reused as per OAuth spec.
         """
-        #import ipdb; ipdb.set_trace()
         if 'Authorization' in prepared_request.headers:
             # If we get redirected to a new host, we should strip out
             # any authentication headers.


### PR DESCRIPTION
- Add support for request token and access token in json format. For example in [Kuaipan.cn API](http://www.kuaipan.cn/developers/document_oauth.htm).
- Add verifier parameters to OAuth1Session.fetch_access_token() for convenience.
- Fix issue of redundant oauth rebuilding when binary response without authorization after redirects.
