### PR TITLE
removing slash from MANIFEST.in to fix pip install on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.rst LICENSE HISTORY.rst requirements.txt AUTHORS.rst
-graft tests/
-graft docs/
+graft tests
+graft docs


### PR DESCRIPTION
The slash was breaking Windows install when installing with pip:

```
λ pip install requests-oauthlib
Downloading/unpacking requests-oauthlib
  Running setup.py egg_info for package requests-oauthlib

    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "c:\users\markne~1\appdata\local\temp\pip-build-marknemec\requests-oauthlib\setup.py", line 66, in <module>
        setup(**settings)
      File "C:\Python27\lib\distutils\core.py", line 152, in setup
        dist.run_commands()
      File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
        cmd_obj.run()
      File "<string>", line 14, in replacement_run
      File "build\bdist.win32\egg\setuptools\command\egg_info.py", line 193, in find_sources
      File "build\bdist.win32\egg\setuptools\command\egg_info.py", line 279, in run
      File "C:\Python27\lib\distutils\command\sdist.py", line 316, in read_template
        self.filelist.process_template_line(line)
      File "C:\Python27\lib\distutils\filelist.py", line 118, in process_template_line
        action, patterns, dir, dir_pattern = self._parse_template_line(line)
      File "C:\Python27\lib\distutils\filelist.py", line 105, in _parse_template_line
        dir_pattern = convert_path(words[1])
      File "C:\Python27\lib\distutils\util.py", line 201, in convert_path
        raise ValueError, "path '%s' cannot end with '/'" % pathname
    ValueError: path 'tests/' cannot end with '/'
    Complete output from command python setup.py egg_info:
    running egg_info

writing requirements to pip-egg-info\requests_oauthlib.egg-info\requires.txt

writing pip-egg-info\requests_oauthlib.egg-info\PKG-INFO

writing top-level names to pip-egg-info\requests_oauthlib.egg-info\top_level.txt

writing dependency_links to pip-egg-info\requests_oauthlib.egg-info\dependency_links.txt

warning: manifest_maker: standard file '-c' not found



reading manifest file 'pip-egg-info\requests_oauthlib.egg-info\SOURCES.txt'

reading manifest template 'MANIFEST.in'

Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "c:\users\markne~1\appdata\local\temp\pip-build-marknemec\requests-oauthlib\setup.py", line 66, in <module>

    setup(**settings)

  File "C:\Python27\lib\distutils\core.py", line 152, in setup

    dist.run_commands()

  File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands

    self.run_command(cmd)

  File "C:\Python27\lib\distutils\dist.py", line 972, in run_command

    cmd_obj.run()

  File "<string>", line 14, in replacement_run

  File "build\bdist.win32\egg\setuptools\command\egg_info.py", line 193, in find_sources

  File "build\bdist.win32\egg\setuptools\command\egg_info.py", line 279, in run

  File "C:\Python27\lib\distutils\command\sdist.py", line 316, in read_template

    self.filelist.process_template_line(line)

  File "C:\Python27\lib\distutils\filelist.py", line 118, in process_template_line

    action, patterns, dir, dir_pattern = self._parse_template_line(line)

  File "C:\Python27\lib\distutils\filelist.py", line 105, in _parse_template_line

    dir_pattern = convert_path(words[1])

  File "C:\Python27\lib\distutils\util.py", line 201, in convert_path

    raise ValueError, "path '%s' cannot end with '/'" % pathname

ValueError: path 'tests/' cannot end with '/'

----------------------------------------
Command python setup.py egg_info failed with error code 1 in c:\users\markne~1\appdata\local\temp\pip-build-marknemec\requests-oauthlib
Storing complete log in C:\Users\marknemec\pip\pip.log
```

and raising warnings when installing on *nix with pip:

```
$ pip install requests-oauthlib
Downloading/unpacking requests-oauthlib
  Downloading requests-oauthlib-0.4.1.tar.gz
  Running setup.py egg_info for package requests-oauthlib

    warning: no directories found matching 'tests/'
    warning: no directories found matching 'docs/'
Downloading/unpacking oauthlib>=0.6.2 (from requests-oauthlib)
  Downloading oauthlib-0.6.3.tar.gz (100kB): 100kB downloaded
  Running setup.py egg_info for package oauthlib

Downloading/unpacking requests>=2.0.0 (from requests-oauthlib)
  Downloading requests-2.3.0.tar.gz (429kB): 429kB downloaded
  Running setup.py egg_info for package requests

Installing collected packages: requests-oauthlib, oauthlib, requests
  Running setup.py install for requests-oauthlib

    warning: no directories found matching 'tests/'
    warning: no directories found matching 'docs/'
  Running setup.py install for oauthlib

  Running setup.py install for requests

Successfully installed requests-oauthlib oauthlib requests
Cleaning up...
```
