### PR TITLE
Integrate with Travis CI and Coveralls, and display badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+script:
+  - coverage run -m nose
+after_success:
+  - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Requests-OAuthlib
-=================
+Requests-OAuthlib |build-status| |coverage-status| |docs|
+=========================================================
 
 This project provides first-class OAuth library support for `Requests <http://python-requests.org>`_.
 
@@ -55,3 +55,12 @@ To install requests and requests_oauthlib you can use pip:
 .. code-block:: bash
 
     $ pip install requests requests_oauthlib
+
+.. |build-status| image:: https://travis-ci.org/requests/requests-oauthlib.svg?branch=master
+   :target: https://travis-ci.org/requests/requests-oauthlib
+.. |coverage-status| image:: https://img.shields.io/coveralls/requests/requests-oauthlib.svg
+   :target: https://coveralls.io/r/requests/requests-oauthlib
+.. |docs| image:: https://readthedocs.org/projects/requests-oauthlib/badge/?version=latest
+   :alt: Documentation Status
+   :scale: 100%
+   :target: https://readthedocs.org/projects/requests-oauthlib/


### PR DESCRIPTION
To report data to [Travis](https://travis-ci.org) and [Coveralls](http://coveralls.io), you'll need to sign in to those websites via Github OAuth and ask them to start tracking this repo. Otherwise, you should be all set!
