### PR TITLE
Provide coverage source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - pip install -r requirements.txt
   - pip install coveralls
 script:
-  - coverage run -m nose
+  - coverage run --source=requests_oauthlib -m nose
 after_success:
   - coveralls


### PR DESCRIPTION
So that it doesn't report an artificially low coverage percentage.
We only care about covering this module, not all modules that
this module imports.
