### PR TITLE
[FIX] ImportError: cannot import name to_native_string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests>=2.0.0
 oauthlib[rsa]>=0.6.2


### PR DESCRIPTION
`requests` lib version should be >= 2.0.0 for `requests.utils.to_native_string` to be available

See: http://stackoverflow.com/a/24955127/798575
