### PR TITLE
Update requirements.txt to fix build errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.0.0
-oauthlib[rsa]>=0.6.2
+oauthlib[rsa]=0.6.3


### PR DESCRIPTION
oauthlib has been upgraded quite recently, and it is causing errors with Twython because of the new oauth. I have fixed the issue by downgrading to oauthlib 0.6.3 locally.

As seen here: https://github.com/idan/oauthlib/commits/master
