### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.0.0
-oauthlib[rsa]>=0.6.2
+oauthlib[rsa]==0.6.3


### PR DESCRIPTION
oauthlib has been upgraded quite recently, and it is causing errors with Twython because of oauthlib. I have fixed the issue by downgrading to oauthlib 0.6.3 locally.

Here are the recent changes of oauthlib: https://github.com/idan/oauthlib/commits/master
