### PR TITLE
Fix TypeError in TokenMissing class (call to parent)

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -42,7 +42,7 @@ class TokenRequestDenied(ValueError):
 
 class TokenMissing(ValueError):
     def __init__(self, message, response):
-        super(TokenRequestDenied, self).__init__(message)
+        super(TokenMissing, self).__init__(message)
         self.response = response
 
 


### PR DESCRIPTION
When the TokenMissing exception is raised, a TypeError exception is raised: `TypeError: super(type, obj): obj must be an instance or subtype of type`.

This is because when calling the parent ValueError class, TokenRequestDenied is passed to super() instead of TokenMissing. This is probably due to a bad copy&paste from the code of the TokenRequestDenied right above.
