### PR TITLE
Check if client exists before referencing client_id

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -64,7 +64,9 @@ class OAuth2Session(requests.Session):
         :param kwargs: Arguments to pass to the Session constructor.
         """
         super(OAuth2Session, self).__init__(**kwargs)
-        self.client_id = client_id or client.client_id
+        self.client_id = client_id
+        if client is not None and not self.client_id:
+            self.client_id = client.client_id
         self.scope = scope
         self.redirect_uri = redirect_uri
         self.token = token or {}


### PR DESCRIPTION
I'm trying to instantiate an `OAuth2Session` object, and populate information (like `client_id`) *after* the initialization code has already run. This change is necessary for that -- otherwise, I get `AttributeError: 'NoneType' object has no attribute 'client_id'`