### PR TITLE
Add Slack compliance

### DIFF
--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 
 from .facebook import facebook_compliance_fix
 from .linkedin import linkedin_compliance_fix
+from .slack import slack_compliance_fix
 from .weibo import weibo_compliance_fix

--- a/requests_oauthlib/compliance_fixes/slack.py
+++ b/requests_oauthlib/compliance_fixes/slack.py
@@ -1,0 +1,11 @@
+from oauthlib.common import add_params_to_uri
+
+
+def slack_compliance_fix(session):
+    def _non_compliant_param_name(url, headers, data):
+        token = [('token', session._client.access_token)]
+        url = add_params_to_uri(url, token)
+        return url, headers, data
+
+    session.register_compliance_hook('protected_request', _non_compliant_param_name)
+    return session


### PR DESCRIPTION
This PR fix a bug that its get method always returns 'not_authed' on Slack.

To call api methods on Slack, it require a URL including 'token' .