### PR TITLE
Update Legacy Application Flow documentation

### DIFF
--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -109,8 +109,25 @@ Documentation coming soon. Want to help? Why not `write this section`_?
 Legacy Application Flow
 -----------------------
 
-Documentation coming soon. Want to help? Why not `write this section`_?
+The steps below outline how to use the Resource Owner Password Credentials Grant Type flow to obtain an access token.
 
+0. You will need the following settings. ``client_secret`` is optional depending on the provider.
+
+.. code-block:: pycon
+
+    >>> client_id = 'your_client_id'
+    >>> client_secret = 'your_client_secret'
+    >>> username = 'your_username'
+    >>> password = 'your_password'
+
+1. Fetch an access token from the provider.
+
+.. code-block:: pycon
+
+    >>> oauth = OAuth2Session(client=LegacyApplicationClient(client_id=client_id))
+    >>> token = oauth.fetch_token(token_url='https://somesite.com/oauth2/token',
+            username=username, password=password, client_id=client_id,
+            client_secret=client_secret)
 
 .. _backend-application-flow:
 


### PR DESCRIPTION
I added a basic description of the Legacy Application Flow. It's pretty simple, but it took a bit of tooling around so this should save some people the trouble.

I discovered that client_id is not passed from the OAuth2Session or LegacyApplicationClient when fetch_token is called, which I believe to be a bug.