### PR TITLE
[bugfix] Add headers in refresh_token flow

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -217,7 +217,7 @@ class OAuth2Session(requests.Session):
         return self.token
 
     def refresh_token(self, token_url, refresh_token=None, body='', auth=None,
-                      timeout=None, verify=True, **kwargs):
+                      timeout=None, headers=None, verify=True, **kwargs):
         """Fetch a new access token using a refresh token.
 
         :param token_url: The token endpoint, must be HTTPS.
@@ -246,8 +246,14 @@ class OAuth2Session(requests.Session):
         body = self._client.prepare_refresh_body(body=body,
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
+
+        headers = headers or {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        }
+
         r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
-                      timeout=timeout, verify=verify)
+                      timeout=timeout, headers=headers, verify=verify)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',


### PR DESCRIPTION
Indeed, we are sending default headers when fetching a token. I thought
it was logic to also send these same default headers (and offer our
users the possibility to set their own headers) in the `refresh_token`
method.

Also, one of the main reason for this is that some applications (the
Flowdock API for instance) do need those headers to return the
appropriate content :)