### PR TITLE
When refreshing tokens, pass through **kwargs

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -284,7 +284,7 @@ class OAuth2Session(requests.Session):
                 if self.auto_refresh_url:
                     log.debug('Auto refresh is set, attempting to refresh at %s.',
                               self.auto_refresh_url)
-                    token = self.refresh_token(self.auto_refresh_url)
+                    token = self.refresh_token(self.auto_refresh_url, **kwargs)
                     if self.token_updater:
                         log.debug('Updating token to %s using %s.',
                                   token, self.token_updater)


### PR DESCRIPTION
When tokens are refreshed, the **kwargs are not passed through to refresh_tokens. This will lead to parameters like SSL verification, authentication and timeout settings to be dropped.

This patch fixes the problem.