### PR TITLE
Don't intercept HTTP errors before OAuthlib can handle them

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -198,8 +198,6 @@ class OAuth2Session(requests.Session):
             log.debug('Invoking hook %s.', hook)
             r = hook(r)
 
-        r.raise_for_status()
-
         self._client.parse_request_body_response(r.text, scope=self.scope)
         self.token = self._client.token
         log.debug('Obtained token %s.', self.token)


### PR DESCRIPTION
As per https://github.com/requests/requests-oauthlib/issues/178#issuecomment-142280502 - the addition of this line caused a regression; the HTTP errors aren't passed on to OAuthlib anymore breaking the exceptions that would normally be raised.