### PR TITLE
Raise possible exceptions in refresh_token

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -246,6 +246,7 @@ class OAuth2Session(requests.Session):
         log.debug('Prepared refresh token request body %s', body)
         r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
                       timeout=timeout, verify=verify)
+        r.raise_for_status()
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',


### PR DESCRIPTION
Hi!
My scenario: trying to refresh a token, Digital Ocean's API returned 429 (too many requests) but no error were raised, so the exception was masked as `MissingTokenError(description="Missing access token parameter.")`.