### PR TITLE
Added authorization header for token access

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -168,6 +168,8 @@ class OAuth2Session(requests.Session):
                 redirect_uri=self.redirect_uri, username=username,
                 password=password, **kwargs)
 
+        auth = auth or requests.auth.HTTPBasicAuth(username, password)
+
         headers = headers or {
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',


### PR DESCRIPTION
This change adds a Basic Auth header into `fetch_token`.
Why?

The relevant section of the OAuth 2.0 specification, [2.3.1. Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) reads:

> Clients in possession of a client password MAY use the
> HTTP Basic authentication scheme...

But for servers, it reads:

> The authorization server MUST support the
> HTTP Basic authentication scheme for authenticating clients
> that were issued a client password.

Clients MAY send Basic Auth,
but servers MUST accept it.
Before this commit, `fetch_token` DOES NOT use this scheme.
Instead, it sends `client_id` and `client_secret` in the body.
The spec says this about that:

> Including the client credentials in the request-body
> using the two parameters is NOT RECOMMENDED
> and SHOULD be limited to clients unable to directly utilize
> the HTTP Basic authentication scheme...

But for servers, it reads:

> The authorization server MAY support including
> the client credentials in the request-body...

Clients are NOT RECOMMENDED to send a body,
and servers MAY accept it.
So this client DOES something that is NOT RECOMMENDED.
However, Fixing that would be a breaking change.
Furthermore, this clearly works for non-compliant OAuth servers.
"Ain't broke so don't fix it."

A compliant server may accept Basic Auth and not a request-body.
Which is the current case for Bitbucket.
Before this commit, the following is a simple work-around:

```
    # Fetch the access token
    basic_auth = HTTPBasicAuth(client_id, client_secret)
    bitbucket.fetch_token(
      token_uri,
      authorization_response=redirect_response,
      auth=basic_auth)
```

With a one line change (and 50+ lines of commit message),
`fetch_token` is now more compliant and works with Bitbucket.