### PR TITLE
Getters/Setters for wrapped attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install coveralls
+  - python setup.py develop
 script:
   - coverage run --source=requests_oauthlib -m nose
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install coveralls
-  - python setup.py develop
+  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
 script:
   - coverage run --source=requests_oauthlib -m nose
 after_success:

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -64,16 +64,15 @@ class OAuth2Session(requests.Session):
         :param kwargs: Arguments to pass to the Session constructor.
         """
         super(OAuth2Session, self).__init__(**kwargs)
+        self._client = client or WebApplicationClient(client_id, token=token)
+        self.token = token or {}
         self.scope = scope
         self.redirect_uri = redirect_uri
-        self.token = token or {}
         self.state = state or generate_token
         self._state = state
         self.auto_refresh_url = auto_refresh_url
         self.auto_refresh_kwargs = auto_refresh_kwargs or {}
         self.token_updater = token_updater
-        self._client = client or WebApplicationClient(client_id, token=token)
-        self._client._populate_attributes(token or {})
 
         # Allow customizations for non compliant providers through various
         # hooks to adjust requests and responses.
@@ -104,6 +103,15 @@ class OAuth2Session(requests.Session):
     @client_id.deleter
     def client_id(self):
         del self._client.client_id
+
+    @property
+    def token(self):
+        return getattr(self._client, "token", None)
+
+    @token.setter
+    def token(self, value):
+        self._client.token = value
+        self._client._populate_attributes(value)
 
     @property
     def access_token(self):

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -64,9 +64,6 @@ class OAuth2Session(requests.Session):
         :param kwargs: Arguments to pass to the Session constructor.
         """
         super(OAuth2Session, self).__init__(**kwargs)
-        self.client_id = client_id
-        if client is not None and not self.client_id:
-            self.client_id = client.client_id
         self.scope = scope
         self.redirect_uri = redirect_uri
         self.token = token or {}
@@ -97,6 +94,30 @@ class OAuth2Session(requests.Session):
         return self._state
 
     @property
+    def client_id(self):
+        return getattr(self._client, "client_id", None)
+
+    @client_id.setter
+    def client_id(self, value):
+        self._client.client_id = value
+
+    @client_id.deleter
+    def client_id(self):
+        del self._client.client_id
+
+    @property
+    def access_token(self):
+        return getattr(self._client, "access_token", None)
+
+    @access_token.setter
+    def access_token(self, value):
+        self._client.access_token = value
+
+    @access_token.deleter
+    def access_token(self):
+        del self._client.access_token
+
+    @property
     def authorized(self):
         """Boolean that indicates whether this session has an OAuth token
         or not. If `self.authorized` is True, you can reasonably expect
@@ -105,7 +126,7 @@ class OAuth2Session(requests.Session):
         authentication dance before OAuth-protected requests to the resource
         will succeed.
         """
-        return bool(self._client.access_token)
+        return bool(self.access_token)
 
     def authorization_url(self, url, state=None, **kwargs):
         """Form an authorization URL.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
+tests_require = ['mock']
+if sys.version_info < (2, 7): # Python 2.6 or lower
+    tests_require.append('unittest2')
+
 
 settings.update(
     name=APP_NAME,
@@ -59,7 +63,7 @@ settings.update(
         'Programming Language :: Python :: 3.4',
     ),
     zip_safe=False,
-    tests_require=['mock'],
+    tests_require=tests_require,
     test_suite='tests'
 )
 

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -141,6 +141,26 @@ class OAuth2SessionTest(unittest.TestCase):
                           'https://i.b/token',
                           authorization_response='https://i.b/no-state?code=abc')
 
+    def test_client_id_proxy(self):
+        sess = OAuth2Session('test-id')
+        self.assertEqual(sess.client_id, 'test-id')
+        sess.client_id = 'different-id'
+        self.assertEqual(sess.client_id, 'different-id')
+        sess._client.client_id = 'something-else'
+        self.assertEqual(sess.client_id, 'something-else')
+        del sess.client_id
+        self.assertIsNone(sess.client_id)
+
+    def test_access_token_proxy(self):
+        sess = OAuth2Session('test-id')
+        self.assertIsNone(sess.access_token)
+        sess.access_token = 'test-token'
+        self.assertEqual(sess.access_token, 'test-token')
+        sess._client.access_token = 'different-token'
+        self.assertEqual(sess.access_token, 'different-token')
+        del sess.access_token
+        self.assertIsNone(sess.access_token)
+
     def test_authorized_false(self):
         sess = OAuth2Session('foo')
         self.assertFalse(sess.authorized)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -161,6 +161,25 @@ class OAuth2SessionTest(unittest.TestCase):
         del sess.access_token
         self.assertIsNone(sess.access_token)
 
+    def test_token_proxy(self):
+        token = {
+            'access_token': 'test-access',
+        }
+        sess = OAuth2Session('test-id', token=token)
+        self.assertEqual(sess.access_token, 'test-access')
+        self.assertEqual(sess.token, token)
+        token['access_token'] = 'something-else'
+        sess.token = token
+        self.assertEqual(sess.access_token, 'something-else')
+        self.assertEqual(sess.token, token)
+        sess._client.access_token = 'different-token'
+        token['access_token'] = 'different-token'
+        self.assertEqual(sess.access_token, 'different-token')
+        self.assertEqual(sess.token, token)
+        # can't delete token attribute
+        with self.assertRaises(AttributeError):
+            del sess.token
+
     def test_authorized_false(self):
         sess = OAuth2Session('foo')
         self.assertFalse(sess.authorized)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 import json
 import mock
 import time
-import unittest
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from oauthlib.common import urlencode
 from oauthlib.oauth2 import TokenExpiredError, OAuth2Error
@@ -15,7 +18,7 @@ from requests_oauthlib import OAuth2Session, TokenUpdated
 fake_time = time.time()
 
 
-class OAuth2SessionTest(unittest.TestCase):
+class OAuth2SessionTest(TestCase):
 
     def setUp(self):
         # For python 2.6


### PR DESCRIPTION
Code that uses requests-oauthlib may want to modify values in the oauth2 session client, but requests-oauthlib doesn't expose them in a consistent way. By exposing getters and setters, other software and libraries that wrap requests-oauthlib can modify these values in a consistent way.