### PR TITLE
Subclass requests.auth.AuthBase

### DIFF
--- a/requests_oauthlib/oauth1_auth.py
+++ b/requests_oauthlib/oauth1_auth.py
@@ -8,6 +8,7 @@ from oauthlib.oauth1 import Client, SIGNATURE_HMAC, SIGNATURE_TYPE_AUTH_HEADER
 from oauthlib.oauth1 import SIGNATURE_TYPE_BODY
 from requests.compat import is_py3
 from requests.utils import to_native_string
+from requests.auth import AuthBase
 
 CONTENT_TYPE_FORM_URLENCODED = 'application/x-www-form-urlencoded'
 CONTENT_TYPE_MULTI_PART = 'multipart/form-data'
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 # OBS!: Correct signing of requests are conditional on invoking OAuth1
 # as the last step of preparing a request, or at least having the
 # content-type set properly.
-class OAuth1(object):
+class OAuth1(AuthBase):
     """Signs the request using OAuth 1 (RFC5849)"""
 
     client_class = Client

--- a/requests_oauthlib/oauth2_auth.py
+++ b/requests_oauthlib/oauth2_auth.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
 from oauthlib.oauth2 import is_secure_transport
+from requests.auth import AuthBase
 
 
-class OAuth2(object):
+class OAuth2(AuthBase):
     """Adds proof of authorization (OAuth2 token) to the request."""
 
     def __init__(self, client_id=None, client=None, token=None):


### PR DESCRIPTION
The official documentation says to [subclass `requests.auth.AuthBase`](http://docs.python-requests.org/en/latest/user/authentication/#new-forms-of-authentication), so requests-oauthlib should do that. Requests-oauthlib only supports requests at version 2.0.0 and above, and [the `AuthBase` class existed at version 2.0.0](https://github.com/kennethreitz/requests/blob/2.0/requests/auth.py#L34), so we don't need to worry about ImportErrors.