### PR TITLE
Cleaning the previous token before fetching a new one, to avoid a Tok…

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -206,6 +206,7 @@ class OAuth2Session(requests.Session):
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
         }
+        self.token = {}
         if method.upper() == 'POST':
             r = self.post(token_url, data=dict(urldecode(body)),
                 timeout=timeout, headers=headers, auth=auth,


### PR DESCRIPTION
This change makes sure the session token gets cleaned before fetching a new one.

The reason is: if I fetch a token from the OAuth2 server, and use the session for more time than the expiration time, and try to fetch a token again, the session will raise a TokenExpiredError. Normally one should use the `refresh_token` method for this purpose, but not all OAuth2 server implementations provide a refresh token endpoint (I'm working with one that doesn't), so it's important to allow the fetching of new tokens without checking the validity of previous ones.