### PR TITLE
Add refresh_token_request compliance hook

### DIFF
--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -5,3 +5,4 @@ from .linkedin import linkedin_compliance_fix
 from .slack import slack_compliance_fix
 from .mailchimp import mailchimp_compliance_fix
 from .weibo import weibo_compliance_fix
+from .fitbit import fitbit_compliance_fix

--- a/requests_oauthlib/compliance_fixes/fitbit.py
+++ b/requests_oauthlib/compliance_fixes/fitbit.py
@@ -1,0 +1,15 @@
+import base64
+
+from oauthlib.common import add_params_to_uri
+
+
+def fitbit_compliance_fix(session, client_secret):
+    def _non_compliant_auth_header(url, headers, body):
+        basic_auth_value = "{}:{}".format(session._client.client_id, client_secret)
+        headers["Authorization"] = 'Basic {}'.format(base64.b64encode(basic_auth_value))
+        token = [('token', session._client.access_token)]
+        url = add_params_to_uri(url, token)
+        return url, headers, body
+
+    session.register_compliance_hook('refresh_token_request', _non_compliant_auth_header)
+    return session

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -80,6 +80,7 @@ class OAuth2Session(requests.Session):
             'access_token_response': set([]),
             'refresh_token_response': set([]),
             'protected_request': set([]),
+            'refresh_token_request': set([]),
         }
 
     def new_state(self):
@@ -288,6 +289,10 @@ class OAuth2Session(requests.Session):
                 ),
             }
 
+        for hook in self.compliance_hook['refresh_token_request']:
+            log.debug('Invoking hook %s.', hook)
+            token_url, headers, body = hook(token_url, headers, body)
+
         r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
                       timeout=timeout, headers=headers, verify=verify)
         log.debug('Request to refresh token completed with status %s.',
@@ -351,6 +356,7 @@ class OAuth2Session(requests.Session):
             access_token_response invoked before token parsing.
             refresh_token_response invoked before refresh token parsing.
             protected_request invoked before making a request.
+            refresh_token_request invoked before making a refresh request
 
         If you find a new hook is needed please send a GitHub PR request
         or open an issue.


### PR DESCRIPTION
This hook is to be able to modify refresh token requests. It is useful when doing automatic refreshes.

Also added example for the fitbit developer api, which requires a Authorization header at refresh time.
