### PR TITLE
Fail-fast on server errors.

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -229,6 +229,9 @@ class OAuth2Session(requests.Session):
                   r.headers, r.text)
         log.debug('Invoking %d token response hooks.',
                   len(self.compliance_hook['access_token_response']))
+
+        r.raise_for_status()
+
         for hook in self.compliance_hook['access_token_response']:
             log.debug('Invoking hook %s.', hook)
             r = hook(r)
@@ -296,6 +299,9 @@ class OAuth2Session(requests.Session):
                   r.headers, r.text)
         log.debug('Invoking %d token response hooks.',
                   len(self.compliance_hook['refresh_token_response']))
+
+        r.raise_for_status()
+
         for hook in self.compliance_hook['refresh_token_response']:
             log.debug('Invoking hook %s.', hook)
             r = hook(r)


### PR DESCRIPTION
Most OAuth providers give HTTP error codes if something goes wrong. This calls raise_for_status() instead of failing with MissingTokenError in that case, which is uninformative.

The call is _after_ the blocks of debug statements so that you can still figure out what went wrong, if you know where to look.
