### PR TITLE
Don't nullify token before refresh

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -269,9 +269,7 @@ class OAuth2Session(requests.Session):
         if not is_secure_transport(token_url):
             raise InsecureTransportError()
 
-        # Need to nullify token to prevent it from being added to the request
         refresh_token = refresh_token or self.token.get('refresh_token')
-        self.token = {}
 
         log.debug('Adding auto refresh key word arguments %s.',
                   self.auto_refresh_kwargs)
@@ -288,8 +286,8 @@ class OAuth2Session(requests.Session):
                 ),
             }
 
-        r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
-                      timeout=timeout, headers=headers, verify=verify)
+        r = requests.post(token_url, data=dict(urldecode(body)), auth=auth,
+            timeout=timeout, headers=headers, verify=verify)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -287,7 +287,7 @@ class OAuth2Session(requests.Session):
             }
 
         r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
-            timeout=timeout, headers=headers, verify=verify, _refresh=True)
+            timeout=timeout, headers=headers, verify=verify, withhold_token=True)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',
@@ -304,11 +304,11 @@ class OAuth2Session(requests.Session):
             self.token['refresh_token'] = refresh_token
         return self.token
 
-    def request(self, method, url, data=None, headers=None, _refresh=False, **kwargs):
+    def request(self, method, url, data=None, headers=None, withhold_token=False, **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
         if not is_secure_transport(url):
             raise InsecureTransportError()
-        if self.token and not _refresh:
+        if self.token and not withhold_token:
             log.debug('Invoking %d protected resource request hooks.',
                       len(self.compliance_hook['protected_request']))
             for hook in self.compliance_hook['protected_request']:

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -286,8 +286,8 @@ class OAuth2Session(requests.Session):
                 ),
             }
 
-        r = requests.post(token_url, data=dict(urldecode(body)), auth=auth,
-            timeout=timeout, headers=headers, verify=verify)
+        r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
+            timeout=timeout, headers=headers, verify=verify, _refresh=True)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',
@@ -304,11 +304,11 @@ class OAuth2Session(requests.Session):
             self.token['refresh_token'] = refresh_token
         return self.token
 
-    def request(self, method, url, data=None, headers=None, **kwargs):
+    def request(self, method, url, data=None, headers=None, _refresh=False, **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
         if not is_secure_transport(url):
             raise InsecureTransportError()
-        if self.token:
+        if self.token and not _refresh:
             log.debug('Invoking %d protected resource request hooks.',
                       len(self.compliance_hook['protected_request']))
             for hook in self.compliance_hook['protected_request']:


### PR DESCRIPTION
Hello,

I'm using an OAuth2Session object, with the token autorefresh feature, inside a library. This involves some level of concurrent requests. 

I've noticed that some requests were issued without the Authorization header. This was happening around the refresh requests. I've tracked it to the fact that the token was nullified inside the refresh_token method, causing my OAuth2Session instance to lack a token for a short period of time (until a new one is fetched).

The attached changes fixed the issue for me (no token reset, and issue a regular requests.post instead of using the class equivalent). That way the token is simply replaced.

Regards.





