### PR TITLE
Allow kwargs for fetch_request_token and fetch_access_token to be passed to requests.session

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -344,7 +344,7 @@ class OAuth1Session(requests.Session):
 
     def _fetch_token(self, url, **request_kwargs):
         log.debug('Fetching token from %s using client %s', url, self._client.client)
-        r = self.post(url, request_kwargs)
+        r = self.post(url, **request_kwargs)
 
         if r.status_code >= 400:
             error = "Token request failed with code %s, response was '%s'."

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -188,10 +188,30 @@ class OAuth1SessionTest(unittest.TestCase):
             self.assertTrue(isinstance(k, unicode_type))
             self.assertTrue(isinstance(v, unicode_type))
 
+    def test_fetch_request_token_with_optional_arguments(self):
+        auth = OAuth1Session('foo')
+        auth.send = self.fake_body('oauth_token=foo')
+        resp = auth.fetch_request_token('https://example.com/token',
+                                        verify=False, stream=True)
+        self.assertEqual(resp['oauth_token'], 'foo')
+        for k, v in resp.items():
+            self.assertTrue(isinstance(k, unicode_type))
+            self.assertTrue(isinstance(v, unicode_type))
+
     def test_fetch_access_token(self):
         auth = OAuth1Session('foo', verifier='bar')
         auth.send = self.fake_body('oauth_token=foo')
         resp = auth.fetch_access_token('https://example.com/token')
+        self.assertEqual(resp['oauth_token'], 'foo')
+        for k, v in resp.items():
+            self.assertTrue(isinstance(k, unicode_type))
+            self.assertTrue(isinstance(v, unicode_type))
+
+    def test_fetch_access_token_with_optional_arguments(self):
+        auth = OAuth1Session('foo', verifier='bar')
+        auth.send = self.fake_body('oauth_token=foo')
+        resp = auth.fetch_access_token('https://example.com/token',
+                                       verify=False, stream=True)
         self.assertEqual(resp['oauth_token'], 'foo')
         for k, v in resp.items():
             self.assertTrue(isinstance(k, unicode_type))


### PR DESCRIPTION
This was basically suggested in the comments of #149. As i can't commit to this open pull request i make a new one. 
Allow users to pass kwargs to fetch_request_token and fetch_access_token that are then passed to the post method of requests.session. 
I need this for disabling SSL-verification for certain calls. But I don't think it makes sense to implement every possible parameter individually.