### PR TITLE
Google has changed OAuth 2.0 endpoints

### DIFF
--- a/docs/examples/google.rst
+++ b/docs/examples/google.rst
@@ -15,8 +15,8 @@ a callback URL then you can try out the command line interactive example below.
     >>> redirect_uri = 'https://your.registered/callback'
 
     >>> # OAuth endpoints given in the Google API documentation
-    >>> authorization_base_url = "https://accounts.google.com/o/oauth2/auth"
-    >>> token_url = "https://accounts.google.com/o/oauth2/token"
+    >>> authorization_base_url = "https://www.googleapis.com/oauth2/v4/token"
+    >>> token_url = "https://accounts.google.com/o/oauth2/v2/auth"
     >>> scope = [
     ...     "https://www.googleapis.com/auth/userinfo.email",
     ...     "https://www.googleapis.com/auth/userinfo.profile"


### PR DESCRIPTION
As described in OAuth api documentation[1] endpoints has changed 

Fix #222 

1: https://developers.google.com/identity/protocols/OAuth2WebServer