### PR TITLE
Allows tokens to be refreshed via a proxy

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -258,7 +258,7 @@ class OAuth2Session(requests.Session):
         return self.token
 
     def refresh_token(self, token_url, refresh_token=None, body='', auth=None,
-                      timeout=None, headers=None, verify=True, **kwargs):
+                      timeout=None, headers=None, verify=True, proxies=None, **kwargs):
         """Fetch a new access token using a refresh token.
 
         :param token_url: The token endpoint, must be HTTPS.
@@ -295,7 +295,7 @@ class OAuth2Session(requests.Session):
             }
 
         r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
-            timeout=timeout, headers=headers, verify=verify, withhold_token=True)
+            timeout=timeout, headers=headers, verify=verify, withhold_token=True, proxies=proxies)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',


### PR DESCRIPTION
Hi.
I was using your library to access a webbased API via a proxy server.  The proxy requires authentication.  I found I couldn't refresh the token without adding the proxies parameter to the QAuth2Session class.
I have no idea if this raises other security issues but it works for my useage.  I thought I'd see if was useful in the general sense by creating this pull request.
Thanks,
Chris