### PR TITLE
Allow explicit bypass of basic auth logic branch and fetching of tokens via proxy

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -198,7 +198,7 @@ class OAuth2Session(requests.Session):
                 password=password, **kwargs)
 
         client_id = kwargs.get('client_id', '')
-        if not auth:
+        if auth is None:
             if client_id:
                 log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
                 client_secret = kwargs.get('client_secret', '')

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -154,7 +154,7 @@ class OAuth2Session(requests.Session):
 
     def fetch_token(self, token_url, code=None, authorization_response=None,
             body='', auth=None, username=None, password=None, method='POST',
-            timeout=None, headers=None, verify=True, **kwargs):
+            timeout=None, headers=None, verify=True, proxies=None, **kwargs):
         """Generic method for fetching an access token from the token endpoint.
 
         If you are using the MobileApplicationClient you will want to use
@@ -218,13 +218,13 @@ class OAuth2Session(requests.Session):
         if method.upper() == 'POST':
             r = self.post(token_url, data=dict(urldecode(body)),
                 timeout=timeout, headers=headers, auth=auth,
-                verify=verify)
+                verify=verify, proxies=proxies)
             log.debug('Prepared fetch token request body %s', body)
         elif method.upper() == 'GET':
             # if method is not 'POST', switch body to querystring and GET
             r = self.get(token_url, params=dict(urldecode(body)),
                 timeout=timeout, headers=headers, auth=auth,
-                verify=verify)
+                verify=verify, proxies=proxies)
             log.debug('Prepared fetch token request querystring %s', body)
         else:
             raise ValueError('The method kwarg must be POST or GET.')


### PR DESCRIPTION
Some apps do not require the Basic Auth header when fetching a token, and some even outright fail. This happened to me with one of my projects earlier today. With this PR, the basic auth logic branch will only run if `auth` is explicitly `None` e.g. not passing the `auth` kwarg. Specifying `auth=False` will bypass said branch.

I also added support for running `fetch_token()` via a proxy since it is kind of weird that #235 exists for `refresh_token()`, but not for fetching. That and debugging is so much easier with an intercepting proxy which also helped me with the former problem.