### PR TITLE
Add requests-mock to tox dependencies.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=
     nose
     mock
     coveralls
+    requests-mock
 commands= coverage run --source=requests_oauthlib -m nose
 
 [testenv:py26]
@@ -16,3 +17,4 @@ deps=
     mock
     coveralls
     unittest2
+    requests-mock


### PR DESCRIPTION
This turns out to have been missing, which makes validating the library before release a bit tricky!