### PR TITLE
Strips new lines in fetch_token response body

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -352,7 +352,7 @@ class OAuth1Session(requests.Session):
 
         log.debug('Decoding token from response "%s"', r.text)
         try:
-            token = dict(urldecode(r.text))
+            token = dict(urldecode(r.text.strip()))
         except ValueError as e:
             error = ("Unable to decode token from token response. "
                      "This is commonly caused by an unsuccessful request where"


### PR DESCRIPTION
This change strips new line characters from the response body when requesting access tokens from an oauth server. This solves an error I was encountering when trying to authenticate against the WordPress API which returns a new line after the headers and before the URI-encoded response. 

This is the format specified in [Section 2.3 of RFC 5849](https://tools.ietf.org/html/rfc5849#section-2.3) however validation of the response was failing as \r and \n are not safe characters as defined by oauthlib. This caused an exception to be thrown when calling oauthlib's urldecode function on line 30 of oauth1_session.py. By striping those characters before calling urldecode, the presence of a new line in the response body does not cause an exception to be thrown.