### PR TITLE
add a fitbit compliance fix

### DIFF
--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .facebook import facebook_compliance_fix
+from .fitbit import fitbit_compliance_fix
 from .linkedin import linkedin_compliance_fix
 from .slack import slack_compliance_fix
 from .mailchimp import mailchimp_compliance_fix

--- a/requests_oauthlib/compliance_fixes/fitbit.py
+++ b/requests_oauthlib/compliance_fixes/fitbit.py
@@ -1,0 +1,26 @@
+"""
+The Fitbit API breaks from the OAuth2 RFC standard by returning an "errors"
+object list, rather than a single "error" string. This puts hooks in place so
+that oauthlib can process an error in the results from access token and refresh
+token responses. This is necessary to prevent getting the generic red herring
+MissingTokenError.
+"""
+
+from json import loads, dumps
+
+from oauthlib.common import to_unicode
+
+
+def fitbit_compliance_fix(session):
+
+    def _missing_error(r):
+        token = loads(r.text)
+        if 'errors' in token:
+            # Set the error to the first one we have
+            token['error'] = token['errors'][0]['errorType']
+        r._content = to_unicode(dumps(token)).encode('UTF-8')
+        return r
+
+    session.register_compliance_hook('access_token_response', _missing_error)
+    session.register_compliance_hook('refresh_token_response', _missing_error)
+    return session


### PR DESCRIPTION
This adds a compliance fix for the Fitbit API so that errors that occur during access token or refresh token fetching get properly surfaced.
https://dev.fitbit.com/docs/oauth2/#authorization-errors

We have been using this successfully with the python-fitbit library for a few weeks now: https://github.com/orcasgit/python-fitbit/blob/master/fitbit/compliance.py