### PR TITLE
Modify token auto refresh handling.

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -279,9 +279,6 @@ class OAuth2Session(requests.Session):
 
         refresh_token = refresh_token or self.token.get('refresh_token')
 
-        log.debug('Adding auto refresh key word arguments %s.',
-                  self.auto_refresh_kwargs)
-        kwargs.update(self.auto_refresh_kwargs)
         body = self._client.prepare_refresh_body(body=body,
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
@@ -334,21 +331,9 @@ class OAuth2Session(requests.Session):
                     log.debug('Auto refresh is set, attempting to refresh at %s.',
                               self.auto_refresh_url)
 
-                    refresh_kwargs = {}
-                    # If caller provided auto_refresh_kwargs, don't send kwargs
-                    if not self.auto_refresh_kwargs:
-                        # Send kargs (preserve behavior) if caller did not
-                        # specify auto_refresh_kwargs.
-                        refresh_kwargs.update(kwargs)
-                        # If caller did not specify auth in kwargs, provide one.
-                        if client_id and client_secret and 'auth' not in refresh_kwargs:
-                            log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
-                            refresh_kwargs['auth'] = \
-                                requests.auth.HTTPBasicAuth(client_id, client_secret)
-                    # Call refresh_token(), it merges self.auto_refresh_kwargs
-                    # if provided by caller.
+                    # Call refresh_token(), pass any kwargs registered to it.
                     token = self.refresh_token(
-                        self.auto_refresh_url, **refresh_kwargs
+                        self.auto_refresh_url, **self.auth_refresh_kwargs
                     )
                     if self.token_updater:
                         log.debug('Updating token to %s using %s.',

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -297,7 +297,6 @@ class OAuth2Session(requests.Session):
 
         refresh_token = refresh_token or self.token.get('refresh_token')
 
-        log.debug('Kwargs: %s', kwargs)
         body = self._client.prepare_refresh_body(body=body,
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
@@ -333,7 +332,6 @@ class OAuth2Session(requests.Session):
         """Intercept all requests and add the OAuth 2 token if present."""
         if not is_secure_transport(url):
             raise InsecureTransportError()
-
         if self.token and not withhold_token:
             log.debug('Invoking %d protected resource request hooks.',
                       len(self.compliance_hook['protected_request']))
@@ -359,7 +357,7 @@ class OAuth2Session(requests.Session):
                     # Start with kwargs explicitly requested for refresh.
                     refresh_kwargs = self.auto_refresh_kwargs.copy()
 
-                    if 'auth' in kwargs:
+                    if kwargs.get('auth', None):
                         # If user supplied `auth` to `request()` warn them to
                         # instead use `auto_refresh_kwargs`. But honor their
                         # intent for now.

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -334,10 +334,6 @@ class OAuth2Session(requests.Session):
         if not is_secure_transport(url):
             raise InsecureTransportError()
 
-        if client_id or client_secret:
-            warnings.warn(
-                'Specify token refresh authentication in auto_refresh_kwargs.')
-
         if self.token and not withhold_token:
             log.debug('Invoking %d protected resource request hooks.',
                       len(self.compliance_hook['protected_request']))

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -15,7 +15,7 @@ from oauthlib.oauth2 import MismatchingStateError
 from oauthlib.oauth2 import WebApplicationClient, MobileApplicationClient
 from oauthlib.oauth2 import LegacyApplicationClient, BackendApplicationClient
 from requests_oauthlib import OAuth2Session, TokenUpdated
-
+from requests.auth import HTTPBasicAuth
 
 fake_time = time.time()
 
@@ -137,6 +137,14 @@ class OAuth2SessionTest(TestCase):
                     token_updater=token_updater)
             auth.send = fake_refresh_with_auth
             auth.get('https://i.b', client_id='foo', client_secret='bar')
+
+        # Make sure auth param is passed through
+        for client in self.clients:
+            auth = OAuth2Session(client=client, token=self.expired_token,
+                    auto_refresh_url='https://i.b/refresh',
+                    token_updater=token_updater)
+            auth.send = fake_refresh_with_auth
+            auth.get('https://i.b', auth=HTTPBasicAuth('foo', 'bar'))
 
     @mock.patch("time.time", new=lambda: fake_time)
     def test_token_from_fragment(self):


### PR DESCRIPTION
I think these changes make things more explicit. I chose to preserve old functionality with warnings rather than outright remove them.

All of the old functionality can be achieved through the use of `auto_refresh_kwargs`, the preferred explicit method.

I have not yet tested this in my codebase, but the old and new tests all pass. I added some missing tests for old functionality as well as tests for the new stuff.