### PR TITLE
Added example and documentation edit for BackendApplicationClient

### DIFF
--- a/docs/examples/wso2.rst
+++ b/docs/examples/wso2.rst
@@ -1,0 +1,31 @@
+WSO2 OAuth 2 Tutorial
+==========================
+
+Setup subscriptions following the instructions on your WSO2 gateway.  When you
+have obtained a ``client_id`` and a ``client_secret`` you can try out the
+command line interactive example below.
+
+
+.. code-block:: pycon
+
+    >>> from requests.auth import HTTPBasicAuth
+    >>> from oauthlib.oauth2 import BackendApplicationClient
+    >>> from requests_oauthlib import OAuth2Session
+
+    >>> #grab client_id and client_secret:
+    >>> client_id = u'<clientid>'
+    >>> client_secret = u'<secret>'
+    >>> token_url = 'https://wso2gateway.myorg.org/token'
+
+    >>> #generate HTTPBasicAuth Header
+    >>> basic_auth = HTTPBasicAuth(client_id, client_secret)
+    >>> client = BackendApplicationClient(client_id=client_id)
+    
+    >>> #start oauth session
+    >>> oauth = OAuth2Session(client=client)
+    >>> token = oauth.fetch_token(token_url=token_url,
+                              auth=basic_auth)
+
+    >>> r = oauth.get(u'https://wso2gateway.myorg.org/api/v1/api',
+    >>>          headers={'Accept':'application/json'})
+    >>> print(r.json())

--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -141,31 +141,31 @@ The steps below outline how to use the Resource Owner Client Credentials Grant T
 0. Obtain credentials from your OAuth provider. At minimum you will
    need a ``client_id`` and ``client_secret``. 
 
-.. code-block:: pycon
-
-    >>> client_id = 'your_client_id'
-    >>> client_secret = 'your_client_secret'
+    .. code-block:: pycon
+    
+        >>> client_id = 'your_client_id'
+        >>> client_secret = 'your_client_secret'
 
 1. Fetch an access token from the provider.
 
-.. code-block:: pycon
+    .. code-block:: pycon
     
-    >>> from oauthlib.oauth2 import BackendApplicationClient
-    >>> client = BackendApplicationClient(client_id=client_id)
-    >>> oauth = OAuth2Session(client=client)
-    >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', client_id=client_id,
-            client_secret=client_secret)
+        >>> from oauthlib.oauth2 import BackendApplicationClient
+        >>> client = BackendApplicationClient(client_id=client_id)
+        >>> oauth = OAuth2Session(client=client)
+        >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', client_id=client_id,
+                client_secret=client_secret)
 
-1. Alternative fetch an access token from the provider that passes secret only via header.
+   If your provider requires that you pass auth credentials in a Basic Auth header, you can do this instead:
 
-.. code-block:: pycon
+    .. code-block:: pycon
     
-    >>> from oauthlib.oauth2 import BackendApplicationClient
-    >>> from requests.auth import HTTPBasicAuth
-    >>> auth = HTTPBasicAuth(client_id, client_secret)
-    >>> client = BackendApplicationClient(client_id=client_id)
-    >>> oauth = OAuth2Session(client=client)
-    >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', auth=auth)
+        >>> from oauthlib.oauth2 import BackendApplicationClient
+        >>> from requests.auth import HTTPBasicAuth
+        >>> auth = HTTPBasicAuth(client_id, client_secret)
+        >>> client = BackendApplicationClient(client_id=client_id)
+        >>> oauth = OAuth2Session(client=client)
+        >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', auth=auth)
                     
 Refreshing tokens
 -----------------

--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -156,7 +156,17 @@ The steps below outline how to use the Resource Owner Client Credentials Grant T
     >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', client_id=client_id,
             client_secret=client_secret)
 
+1. Alternative fetch an access token from the provider that passes secret only via header.
 
+.. code-block:: pycon
+    
+    >>> from oauthlib.oauth2 import BackendApplicationClient
+    >>> from requests.auth import HTTPBasicAuth
+    >>> auth = HTTPBasicAuth(client_id, client_secret)
+    >>> client = BackendApplicationClient(client_id=client_id)
+    >>> oauth = OAuth2Session(client=client)
+    >>> token = oauth.fetch_token(token_url='https://provider.com/oauth2/token', auth=auth)
+                    
 Refreshing tokens
 -----------------
 


### PR DESCRIPTION
The BackendApplicationClient example in the documentation fails for oauth2 gateways that expect the auth to only be in the header and not in the POST body.  In this example WSO2 as implemented by our org.  

The example was parted together from resolved bugs and appears to work against our gateway.  This request it to help others in the same situation. 