### PR TITLE
Fix bytes/str mixups

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,25 +12,10 @@ except ImportError:
     from StringIO import StringIO # python 2
 import unittest
 
-if sys.version[0] == '3':
-    bytes_type = bytes
-else:
-    bytes_type = str
-
 
 @mock.patch('oauthlib.oauth1.rfc5849.generate_timestamp')
 @mock.patch('oauthlib.oauth1.rfc5849.generate_nonce')
 class OAuth1Test(unittest.TestCase):
-
-    def setUp(self):
-        def converting_equals(a, b):
-            if isinstance(a, bytes_type):
-                a = a.decode('utf-8')
-            if isinstance(b, bytes_type):
-                b = b.decode('utf-8')
-            self.assertEquals(a, b)
-
-        self.assertEqual = converting_equals
 
     def testFormEncoded(self, generate_nonce, generate_timestamp):
         """OAuth1 assumes form encoded if content type is not specified."""
@@ -43,16 +28,16 @@ class OAuth1Test(unittest.TestCase):
         a = r.prepare()
 
         self.assertEqual(a.url, 'http://a.b/path?query=retain')
-        self.assertEqual(a.body, 'this=really&is=&+form=encoded')
-        self.assertEqual(a.headers.get('Content-Type'), 'application/x-www-form-urlencoded')
+        self.assertEqual(a.body, b'this=really&is=&+form=encoded')
+        self.assertEqual(a.headers.get('Content-Type'), b'application/x-www-form-urlencoded')
 
         # guess content-type
         r = requests.Request(method='POST', url='http://a.b/path?query=retain',
                 auth=oauth, data='this=really&is=&+form=encoded')
         b = r.prepare()
         self.assertEqual(b.url, 'http://a.b/path?query=retain')
-        self.assertEqual(b.body, 'this=really&is=&+form=encoded')
-        self.assertEqual(b.headers.get('Content-Type'), 'application/x-www-form-urlencoded')
+        self.assertEqual(b.body, b'this=really&is=&+form=encoded')
+        self.assertEqual(b.headers.get('Content-Type'), b'application/x-www-form-urlencoded')
 
         self.assertEqual(a.headers.get('Authorization'),
                 b.headers.get('Authorization'))
@@ -120,11 +105,11 @@ class OAuth1Test(unittest.TestCase):
         data = 'a'
         r = requests.post('http://httpbin.org/get', data=data, auth=oauth)
         self.assertEqual(r.request.headers.get('Content-Type'),
-                         'application/x-www-form-urlencoded')
+                         b'application/x-www-form-urlencoded')
         r = requests.post('http://httpbin.org/get', auth=oauth, data=data,
                           headers={'Content-type': 'application/json'})
         self.assertEqual(r.request.headers.get('Content-Type'),
-                         'application/json')
+                         b'application/json')
 
 
     def test_register_client_class(self, generate_timestamp, generate_nonce):

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -55,9 +55,7 @@ class OAuth2SessionTest(TestCase):
         token = 'Bearer ' + self.token['access_token']
 
         def verifier(r, **kwargs):
-            auth_header = r.headers.get('Authorization', None)
-            if 'Authorization'.encode('utf-8') in r.headers:
-                auth_header = r.headers['Authorization'.encode('utf-8')]
+            auth_header = r.headers.get(str('Authorization'), None)
             self.assertEqual(auth_header, token)
             resp = mock.MagicMock()
             resp.cookes = []
@@ -248,4 +246,3 @@ class OAuth2SessionTest(TestCase):
             self.assertFalse(sess.authorized)
             sess.fetch_token(url)
             self.assertTrue(sess.authorized)
-


### PR DESCRIPTION
Fixes warnigns when running tests with all warnings on:

$ python -b -Wall -m nose

- DeprecationWarning: Please use assertEqual instead.
- BytesWarning: Comparison between bytes and string