### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 cache: pip
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4
@@ -12,7 +11,6 @@ install:
   - pip install -r requirements.txt
   - pip install requests-mock
   - pip install coveralls
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
 script:
   - coverage run --source=requests_oauthlib -m nose
 after_success:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 History
 -------
 
+UNRELEASED
+++++++++++
+
+- **Removed support for Python 2.6.**
+
 v0.8.0 (14 February 2017)
 +++++++++++++++++++++++++
 

--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from .oauth1_auth import OAuth1
 from .oauth1_session import OAuth1Session
 from .oauth2_auth import OAuth2
@@ -11,12 +13,4 @@ if requests.__version__ < '2.0.0':
            'requests-oauthlib expects, please upgrade to 2.0.0 or later.')
     raise Warning(msg % requests.__version__)
 
-import logging
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-   class NullHandler(logging.Handler):
-       def emit(self, record):
-           pass
-
-logging.getLogger('requests_oauthlib').addHandler(NullHandler())
+logging.getLogger('requests_oauthlib').addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,8 @@ import os
 import sys
 import re
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
+
 
 # Get the version
 version_regex = r'__version__ = ["\']([^"\']*)["\']'
@@ -24,20 +22,13 @@ with open('requests_oauthlib/__init__.py', 'r') as f:
 
 APP_NAME = 'requests-oauthlib'
 
-settings = dict()
-
-
 # Publish Helper.
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-tests_require = ['mock', 'requests-mock']
-if sys.version_info < (2, 7): # Python 2.6 or lower
-    tests_require.append('unittest2')
 
-
-settings.update(
+setup(
     name=APP_NAME,
     version=VERSION,
     description='OAuthlib authentication support for Requests.',
@@ -57,7 +48,6 @@ settings.update(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
@@ -66,8 +56,9 @@ settings.update(
         'Programming Language :: Python :: 3.6',
     ),
     zip_safe=False,
-    tests_require=tests_require,
+    tests_require=[
+        'mock',
+        'requests-mock',
+    ],
     test_suite='tests'
 )
-
-setup(**settings)

--- a/tests/test_compliance_fixes.py
+++ b/tests/test_compliance_fixes.py
@@ -1,8 +1,5 @@
 from __future__ import unicode_literals
-try:
-    from unittest2 import TestCase
-except ImportError:
-    from unittest import TestCase
+from unittest import TestCase
 
 import requests
 import requests_mock

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,10 +6,7 @@ import requests
 import requests_oauthlib
 import oauthlib
 import os.path
-try:
-    from io import StringIO # python 3
-except ImportError:
-    from StringIO import StringIO # python 2
+from io import StringIO
 import unittest
 
 

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -3,15 +3,12 @@ import mock
 import unittest
 import sys
 import requests
+from io import StringIO
 
 from oauthlib.oauth1 import SIGNATURE_TYPE_QUERY, SIGNATURE_TYPE_BODY
 from oauthlib.oauth1 import SIGNATURE_RSA, SIGNATURE_PLAINTEXT
 from requests_oauthlib import OAuth1Session
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 try:
     import cryptography
@@ -24,19 +21,6 @@ if sys.version[0] == '3':
 else:
     unicode_type = unicode
     bytes_type = str
-
-# Monkey patch Python 2.6 unittest
-if not hasattr(unittest, 'SkipTest'):
-    unittest.SkipTest = RuntimeWarning
-    unittest.TestResult.real_add_error = unittest.TestResult.addError
-
-    def patched_addError(self, test, exc_info):
-        if exc_info[0] is RuntimeWarning:
-            print(str(exc_info[1]), end=' ', file=sys.stderr)
-            return
-        else:
-            self.real_add_error(test, exc_info)
-    unittest.TestResult.addError = patched_addError
 
 
 TEST_RSA_KEY = (

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -4,10 +4,7 @@ import mock
 import time
 from base64 import b64encode
 from copy import deepcopy
-try:
-    from unittest2 import TestCase
-except ImportError:
-    from unittest import TestCase
+from unittest import TestCase
 
 from oauthlib.common import urlencode
 from oauthlib.oauth2 import TokenExpiredError, OAuth2Error

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy
+envlist = py27, py33, py34, py35, py36, pypy
 
 [testenv]
 deps=
@@ -9,12 +9,3 @@ deps=
     coveralls
     requests-mock
 commands= coverage run --source=requests_oauthlib -m nose
-
-[testenv:py26]
-deps=
-    -r{toxinidir}/requirements.txt
-    nose
-    mock
-    coveralls
-    unittest2
-    requests-mock


### PR DESCRIPTION
I would humbly like to suggest requests-oauthlib drop support for Python
2.6.

The last release of Python 2.6 was 2013-10-29, over 3 years ago. It is
no longer receiving security fixes.

https://www.python.org/dev/peps/pep-0361/

The pip project itself has recently dropped support for 2.6. Their
numbers estimate that Python 2.6 accounts for ~2% of their downloads.

https://github.com/pypa/pip/pull/4343

For projects that still use Python 2.6, they can continue to pip install
an older version.

I've tried my best to remove as much 2.6 specific code as I can,
including the 'Programming Language :: Python :: 2.6' trove classifier
from setup.py. I've also removed Travis CI testing, which should result
in faster testing and fewer wasted resources.

Code removed:

- setup.py cleanups due to fewer version complications
- Testing configuration
- Logging workaround for missing NullHandler
- Removed unittest2 dependency and monkey patching
- StringIO import errors

Thanks for considering.