### PR TITLE
Added "scope=None" argument to fetch_token

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -152,7 +152,7 @@ class OAuth2Session(requests.Session):
                 state=state,
                 **kwargs), state
 
-    def fetch_token(self, token_url, code=None, authorization_response=None,
+    def fetch_token(self, token_url, scope=None, code=None, authorization_response=None,
             body='', auth=None, username=None, password=None, method='POST',
             timeout=None, headers=None, verify=True, proxies=None, **kwargs):
         """Generic method for fetching an access token from the token endpoint.
@@ -193,7 +193,7 @@ class OAuth2Session(requests.Session):
                                  'authorization_response parameters.')
 
 
-        body = self._client.prepare_request_body(code=code, body=body,
+        body = self._client.prepare_request_body(code=code, scope=scope, body=body,
                 redirect_uri=self.redirect_uri, username=username,
                 password=password, **kwargs)
 


### PR DESCRIPTION
In my back-end application it's necessary to pass body as grant_type=client_credentials&scope=bla+blabla.
That is why it can be useful to pass optional argument "scope" to fetch_token and then to prepare_request_body.
Maybe someone will find it useful too.