### PR TITLE
OAuth1Session token property

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -169,6 +169,26 @@ class OAuth1Session(requests.Session):
         self.auth = self._client
 
     @property
+    def token(self):
+        oauth_token = self._client.client.resource_owner_key
+        oauth_token_secret = self._client.client.resource_owner_secret
+        oauth_verifier = self._client.client.verifier
+
+        token_dict = {}
+        if oauth_token:
+            token_dict["oauth_token"] = oauth_token
+        if oauth_token_secret:
+            token_dict["oauth_token_secret"] = oauth_token_secret
+        if oauth_verifier:
+            token_dict["oauth_verifier"] = oauth_verifier
+
+        return token_dict
+
+    @token.setter
+    def token(self, value):
+        self._populate_attributes(value)
+
+    @property
     def authorized(self):
         """Boolean that indicates whether this session has an OAuth token
         or not. If `self.authorized` is True, you can reasonably expect
@@ -322,6 +342,7 @@ class OAuth1Session(requests.Session):
         token = dict(urldecode(urlparse(url).query))
         log.debug('Updating internal client token attribute.')
         self._populate_attributes(token)
+        self.token = token
         return token
 
     def _populate_attributes(self, token):
@@ -359,6 +380,7 @@ class OAuth1Session(requests.Session):
         log.debug('Obtained token %s', token)
         log.debug('Updating internal client attributes from token data.')
         self._populate_attributes(token)
+        self.token = token
         return token
 
     def rebuild_auth(self, prepared_request, response):

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -241,6 +241,42 @@ class OAuth1SessionTest(unittest.TestCase):
         del auth._client.client.verifier
         self._test_fetch_access_token_raises_error(auth)
 
+    def test_token_proxy_set(self):
+        token = {
+            'oauth_token': 'fake-key',
+            'oauth_token_secret': 'fake-secret',
+            'oauth_verifier': 'fake-verifier',
+        }
+        sess = OAuth1Session('foo')
+        self.assertIsNone(sess._client.client.resource_owner_key)
+        self.assertIsNone(sess._client.client.resource_owner_secret)
+        self.assertIsNone(sess._client.client.verifier)
+        self.assertEqual(sess.token, {})
+
+        sess.token = token
+        self.assertEqual(sess._client.client.resource_owner_key, 'fake-key')
+        self.assertEqual(sess._client.client.resource_owner_secret, 'fake-secret')
+        self.assertEqual(sess._client.client.verifier, 'fake-verifier')
+
+    def test_token_proxy_get(self):
+        token = {
+            'oauth_token': 'fake-key',
+            'oauth_token_secret': 'fake-secret',
+            'oauth_verifier': 'fake-verifier',
+        }
+        sess = OAuth1Session(
+            'foo',
+            resource_owner_key=token['oauth_token'],
+            resource_owner_secret=token['oauth_token_secret'],
+            verifier=token['oauth_verifier'],
+        )
+        self.assertEqual(sess.token, token)
+
+        sess._client.client.resource_owner_key = "different-key"
+        token['oauth_token'] = "different-key"
+
+        self.assertEqual(sess.token, token)
+
     def test_authorized_false(self):
         sess = OAuth1Session('foo')
         self.assertFalse(sess.authorized)


### PR DESCRIPTION
This pull request adds a `token` property to the `OAuth1Session` class, to match the `token` property on the `OAuth2Session` class. It also changes the `parse_authorization_response` and `_fetch_token` methods to call the setter for this property.

You may notice that these two methods now call `self._populate_attributes()` immediately followed by the `token` setter, which _also_ calls `self._populate_attributes()`. Why the duplication? Because subclasses may override this `token` property to behave differently, while still expecting the base class to populate its internal attributes. This how [Flask-Dance](https://github.com/singingwolfboy/flask-dance) works -- calling the `token` setter activates the token storage backend.

If you examine the `OAuth2Session` class in this project, you will see that this duplication appears there, as well. This pull request is about making `OAuth1Session` logically consistent with `OAuth2Session`.

See also this issue on the Flask-Dance repository, which was the impetus for creating this pull request: https://github.com/singingwolfboy/flask-dance/issues/120