### PR TITLE
New compliance hook and error handling

### DIFF
--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from .exc import TokenRequestDenied
 from .oauth1_auth import OAuth1
 from .oauth1_session import OAuth1Session
 from .oauth2_auth import OAuth2

--- a/requests_oauthlib/exc.py
+++ b/requests_oauthlib/exc.py
@@ -1,0 +1,10 @@
+class TokenRequestDenied(ValueError):
+
+    def __init__(self, message, response):
+        super(TokenRequestDenied, self).__init__(message)
+        self.response = response
+
+    @property
+    def status_code(self):
+        """For backwards-compatibility purposes"""
+        return self.response.status_code

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -14,6 +14,7 @@ from oauthlib.oauth1 import (
 )
 import requests
 
+from . import exc
 from . import OAuth1
 
 
@@ -27,18 +28,6 @@ def urldecode(body):
     except:
         import json
         return json.loads(body)
-
-
-class TokenRequestDenied(ValueError):
-
-    def __init__(self, message, response):
-        super(TokenRequestDenied, self).__init__(message)
-        self.response = response
-
-    @property
-    def status_code(self):
-        """For backwards-compatibility purposes"""
-        return self.response.status_code
 
 
 class TokenMissing(ValueError):
@@ -365,7 +354,7 @@ class OAuth1Session(requests.Session):
 
         if r.status_code >= 400:
             error = "Token request failed with code %s, response was '%s'."
-            raise TokenRequestDenied(error % (r.status_code, r.text), r)
+            raise exc.TokenRequestDenied(error % (r.status_code, r.text), r)
 
         log.debug('Decoding token from response "%s"', r.text)
         try:

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -210,24 +210,16 @@ class OAuth2Session(requests.Session):
                 log.debug('Encoding username, password as Basic auth credentials.')
                 auth = requests.auth.HTTPBasicAuth(username, password)
 
-        headers = headers or {
-            'Accept': 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        }
         self.token = {}
-        if method.upper() == 'POST':
-            r = self.post(token_url, data=dict(urldecode(body)),
-                timeout=timeout, headers=headers, auth=auth,
-                verify=verify, proxies=proxies)
-            log.debug('Prepared fetch token request body %s', body)
-        elif method.upper() == 'GET':
-            # if method is not 'POST', switch body to querystring and GET
-            r = self.get(token_url, params=dict(urldecode(body)),
-                timeout=timeout, headers=headers, auth=auth,
-                verify=verify, proxies=proxies)
-            log.debug('Prepared fetch token request querystring %s', body)
-        else:
-            raise ValueError('The method kwarg must be POST or GET.')
+
+        r = self._auth_request(method.upper(),
+                               token_url,
+                               body,
+                               timeout=timeout,
+                               headers=headers,
+                               auth=auth,
+                               verify=verify,
+                               proxies=proxies)
 
         log.debug('Request to fetch token completed with status %s.',
                   r.status_code)
@@ -286,16 +278,16 @@ class OAuth2Session(requests.Session):
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
 
-        if headers is None:
-            headers = {
-                'Accept': 'application/json',
-                'Content-Type': (
-                    'application/x-www-form-urlencoded;charset=UTF-8'
-                ),
-            }
+        r = self._auth_request('POST',
+                               token_url,
+                               body,
+                               auth=auth,
+                               timeout=timeout,
+                               headers=headers,
+                               verify=verify,
+                               withhold_token=True,
+                               proxies=proxies)
 
-        r = self.post(token_url, data=dict(urldecode(body)), auth=auth,
-            timeout=timeout, headers=headers, verify=verify, withhold_token=True, proxies=proxies)
         log.debug('Request to refresh token completed with status %s.',
                   r.status_code)
         log.debug('Response headers were %s and content %s.',
@@ -311,6 +303,25 @@ class OAuth2Session(requests.Session):
             log.debug('No new refresh token given. Re-using old.')
             self.token['refresh_token'] = refresh_token
         return self.token
+
+    def _auth_request(self, method, url, body, **kwargs):
+        method = method.upper()
+        data = dict(urldecode(body))
+        kwargs.setdefault('headers', {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        })
+
+        if method == 'POST':
+            kwargs['data'] = data
+            log.debug('Prepared fetch token request body %s', body)
+        elif method == 'GET':
+            kwargs['params'] = data
+            log.debug('Prepared fetch token request querystring %s', body)
+        else:
+            raise ValueError('The method kwarg must be POST or GET.')
+
+        return self.request(method, url, **kwargs)
 
     def request(self, method, url, data=None, headers=None, withhold_token=False,
                 client_id=None, client_secret=None, **kwargs):

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -80,6 +80,7 @@ class OAuth2Session(requests.Session):
             'access_token_response': set(),
             'refresh_token_response': set(),
             'protected_request': set(),
+            'token_request': set(),
         }
 
     def new_state(self):
@@ -320,6 +321,9 @@ class OAuth2Session(requests.Session):
             log.debug('Prepared fetch token request querystring %s', body)
         else:
             raise ValueError('The method kwarg must be POST or GET.')
+
+        for hook in self.compliance_hook['token_request']:
+            method, url, kwargs = hook(method, url, **kwargs)
 
         return self.request(method, url, **kwargs)
 

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -11,7 +11,7 @@ from oauthlib.oauth2 import TokenExpiredError, OAuth2Error
 from oauthlib.oauth2 import MismatchingStateError
 from oauthlib.oauth2 import WebApplicationClient, MobileApplicationClient
 from oauthlib.oauth2 import LegacyApplicationClient, BackendApplicationClient
-from requests_oauthlib import OAuth2Session, TokenUpdated
+from requests_oauthlib import OAuth2Session, TokenUpdated, TokenRequestDenied
 import requests_mock
 
 
@@ -270,5 +270,21 @@ class OAuth2SessionTest(TestCase):
             self.assertFalse(sess.authorized)
             sess.fetch_token(url)
             self.assertTrue(sess.authorized)
+
+        self.assertEqual(len(self.clients), self.requests_mock.call_count)
+
+    def test_token_fetch_invalid_status_code(self):
+        url = 'https://example.com/token'
+        self.requests_mock.post(url,
+                                json={'message': 'Failure'},
+                                status_code=403)
+
+        for client in self.clients:
+            sess = OAuth2Session(client=client)
+            self.assertRaises(
+                TokenRequestDenied,
+                sess.fetch_token,
+                url
+            )
 
         self.assertEqual(len(self.clients), self.requests_mock.call_count)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -12,18 +12,10 @@ from oauthlib.oauth2 import MismatchingStateError
 from oauthlib.oauth2 import WebApplicationClient, MobileApplicationClient
 from oauthlib.oauth2 import LegacyApplicationClient, BackendApplicationClient
 from requests_oauthlib import OAuth2Session, TokenUpdated
+import requests_mock
 
 
 fake_time = time.time()
-
-
-
-def fake_token(token):
-    def fake_send(r, **kwargs):
-        resp = mock.MagicMock()
-        resp.text = json.dumps(token)
-        return resp
-    return fake_send
 
 
 class OAuth2SessionTest(TestCase):
@@ -48,20 +40,24 @@ class OAuth2SessionTest(TestCase):
         ]
         self.all_clients = self.clients + [MobileApplicationClient(self.client_id)]
 
-    def test_add_token(self):
-        token = 'Bearer ' + self.token['access_token']
+        self.requests_mock = requests_mock.mock()
+        self.requests_mock.start()
+        self.addCleanup(self.requests_mock.stop)
 
-        def verifier(r, **kwargs):
-            auth_header = r.headers.get(str('Authorization'), None)
-            self.assertEqual(auth_header, token)
-            resp = mock.MagicMock()
-            resp.cookes = []
-            return resp
+    def test_add_token(self):
+        self.requests_mock.get('https://i.b', text='Ok')
 
         for client in self.all_clients:
             auth = OAuth2Session(client=client, token=self.token)
-            auth.send = verifier
-            auth.get('https://i.b')
+            resp = auth.get('https://i.b')
+            self.assertEqual(200, resp.status_code)
+
+        self.assertEqual(len(self.all_clients),
+                         len(self.requests_mock.request_history))
+
+        token = 'Bearer ' + self.token['access_token']
+        for r in self.requests_mock.request_history:
+            self.assertEqual(token, r.headers.get(str('Authorization'), None))
 
     def test_authorization_url(self):
         url = 'https://example.com/authorize?foo=bar'
@@ -81,57 +77,85 @@ class OAuth2SessionTest(TestCase):
         self.assertIn('response_type=token', auth_url)
 
     @mock.patch("time.time", new=lambda: fake_time)
-    def test_refresh_token_request(self):
+    def test_refresh_token_request_no_refresh(self):
         self.expired_token = dict(self.token)
         self.expired_token['expires_in'] = '-1'
         del self.expired_token['expires_at']
-
-        def fake_refresh(r, **kwargs):
-            if "/refresh" in r.url:
-                self.assertNotIn("Authorization", r.headers)
-            resp = mock.MagicMock()
-            resp.text = json.dumps(self.token)
-            return resp
 
         # No auto refresh setup
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.expired_token)
             self.assertRaises(TokenExpiredError, auth.get, 'https://i.b')
 
+        self.assertFalse(self.requests_mock.called)
+
+    @mock.patch("time.time", new=lambda: fake_time)
+    def test_refresh_token_request_refresh_no_update(self):
+        self.expired_token = dict(self.token)
+        self.expired_token['expires_in'] = '-1'
+        del self.expired_token['expires_at']
+
+        m1 = self.requests_mock.get('https://i.b')
+        m2 = self.requests_mock.post('https://i.b/refresh', json=self.token)
+
         # Auto refresh but no auto update
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.expired_token,
                     auto_refresh_url='https://i.b/refresh')
-            auth.send = fake_refresh
             self.assertRaises(TokenUpdated, auth.get, 'https://i.b')
 
-        # Auto refresh and auto update
-        def token_updater(token):
-            self.assertEqual(token, self.token)
+        self.assertFalse(m1.called)
+        self.assertEquals(len(self.clients), m2.call_count)
+
+    @mock.patch("time.time", new=lambda: fake_time)
+    def test_refresh_token_request_refresh_and_update(self):
+        self.expired_token = dict(self.token)
+        self.expired_token['expires_in'] = '-1'
+        del self.expired_token['expires_at']
+
+        m1 = self.requests_mock.get('https://i.b')
+        m2 = self.requests_mock.post('https://i.b/refresh', json=self.token)
+
+        token_updater = mock.MagicMock()
 
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.expired_token,
                     auto_refresh_url='https://i.b/refresh',
                     token_updater=token_updater)
-            auth.send = fake_refresh
-            auth.get('https://i.b')
+            resp = auth.get('https://i.b')
+            self.assertEqual(200, resp.status_code)
 
-        def fake_refresh_with_auth(r, **kwargs):
-            if "/refresh" in r.url:
-                self.assertIn("Authorization", r.headers)
-                encoded = b64encode(b"foo:bar")
-                content = (b"Basic " + encoded).decode('latin1')
-                self.assertEqual(r.headers["Authorization"], content)
-            resp = mock.MagicMock()
-            resp.text = json.dumps(self.token)
-            return resp
+        self.assertEquals(len(self.clients), m1.call_count)
+        self.assertEquals(len(self.clients), m2.call_count)
+        self.assertEquals(len(self.clients), token_updater.call_count)
+
+    @mock.patch("time.time", new=lambda: fake_time)
+    def test_refresh_token_request_refresh_and_update_2(self):
+        self.expired_token = dict(self.token)
+        self.expired_token['expires_in'] = '-1'
+        del self.expired_token['expires_at']
+
+        m1 = self.requests_mock.get('https://i.b')
+        m2 = self.requests_mock.post('https://i.b/refresh', json=self.token)
+
+        token_updater = mock.MagicMock()
 
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.expired_token,
                     auto_refresh_url='https://i.b/refresh',
                     token_updater=token_updater)
-            auth.send = fake_refresh_with_auth
             auth.get('https://i.b', client_id='foo', client_secret='bar')
+
+        self.assertEquals(len(self.clients), m1.call_count)
+        self.assertEquals(len(self.clients), m2.call_count)
+        self.assertEquals(len(self.clients), token_updater.call_count)
+
+        token = (b"Basic " + b64encode(b"foo:bar")).decode('latin1')
+        for r in m2.request_history:
+            self.assertEquals(token, r.headers["Authorization"])
+
+        for c in token_updater.call_args_list:
+            self.assertEqual(c, mock.call(self.token))
 
     @mock.patch("time.time", new=lambda: fake_time)
     def test_token_from_fragment(self):
@@ -141,19 +165,26 @@ class OAuth2SessionTest(TestCase):
         self.assertEqual(auth.token_from_fragment(response_url), self.token)
 
     @mock.patch("time.time", new=lambda: fake_time)
-    def test_fetch_token(self):
+    def test_fetch_token_good(self):
         url = 'https://example.com/token'
+        self.requests_mock.post(url, json=self.token)
 
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.token)
-            auth.send = fake_token(self.token)
             self.assertEqual(auth.fetch_token(url), self.token)
 
-        error = {'error': 'invalid_request'}
+        self.assertEqual(len(self.clients), self.requests_mock.call_count)
+
+    @mock.patch("time.time", new=lambda: fake_time)
+    def test_fetch_token_invalid(self):
+        url = 'https://example.com/token'
+        self.requests_mock.post(url, json={'error': 'invalid_request'})
+
         for client in self.clients:
             auth = OAuth2Session(client=client, token=self.token)
-            auth.send = fake_token(error)
             self.assertRaises(OAuth2Error, auth.fetch_token, url)
+
+        self.assertEqual(len(self.clients), self.requests_mock.call_count)
 
     def test_cleans_previous_token_before_fetching_new_one(self):
         """Makes sure the previous token is cleaned before fetching a new one.
@@ -170,12 +201,14 @@ class OAuth2SessionTest(TestCase):
         new_token['expires_at'] = now + 3600
         url = 'https://example.com/token'
 
+        self.requests_mock.post(url, json=new_token)
+
         with mock.patch('time.time', lambda: now):
             for client in self.clients:
                 auth = OAuth2Session(client=client, token=self.token)
-                auth.send = fake_token(new_token)
                 self.assertEqual(auth.fetch_token(url), new_token)
 
+            self.assertTrue(len(self.clients), self.requests_mock.call_count)
 
     def test_web_app_fetch_token(self):
         # Ensure the state parameter is used, see issue #105.
@@ -229,17 +262,13 @@ class OAuth2SessionTest(TestCase):
 
     @mock.patch("time.time", new=lambda: fake_time)
     def test_authorized_true(self):
-        def fake_token(token):
-            def fake_send(r, **kwargs):
-                resp = mock.MagicMock()
-                resp.text = json.dumps(token)
-                return resp
-            return fake_send
         url = 'https://example.com/token'
+        self.requests_mock.post(url, json=self.token)
 
         for client in self.clients:
             sess = OAuth2Session(client=client)
-            sess.send = fake_token(self.token)
             self.assertFalse(sess.authorized)
             sess.fetch_token(url)
             self.assertTrue(sess.authorized)
+
+        self.assertEqual(len(self.clients), self.requests_mock.call_count)


### PR DESCRIPTION
* Add a new compliance hook for token_request

Allow us to modify the request that is sent when a new token is requested. This
helps in situations where the standard format is not accepted.

* Use requests-mock for testing

requests-mock is already a dependency for some tests but extend it to the more
core tests.

* Throw an exception on a bad http return code

Throw an error when you get a non 2XX status code because at that point we are
confident there's not going to be a token in the body.