### PR TITLE
fix Oauth2Session post json bug

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+import json as json_lib
 
 from oauthlib.common import generate_token, urldecode
 from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
@@ -312,9 +313,16 @@ class OAuth2Session(requests.Session):
             self.token['refresh_token'] = refresh_token
         return self.token
 
-    def request(self, method, url, data=None, headers=None, withhold_token=False,
+    def request(self, method, url, data=None, json=None, headers=None, withhold_token=False,
                 client_id=None, client_secret=None, **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
+        if not data and json is not None:
+            data = json_lib.dumps(json)
+            if headers is None:
+                headers = {'Content-Type': 'application/json; charset=utf-8'}
+            else:
+                headers.update({'Content-Type': 'application/json; charset=utf-8'})
+
         if not is_secure_transport(url):
             raise InsecureTransportError()
         if self.token and not withhold_token:


### PR DESCRIPTION
OAuth2Session inherits requests.Session.post method which has two key word arguments - json and data -. But when calling OAuth2Session.post with a json payload, an expired token, and auto refresh enabled, the json argument will be passed to OAuth2Session.refresh_token and cause token refreshing failed. 

```python
>>> # something like this will raise an error
>>> session.post('https://...', json=data_obj)
...
oauthlib.oauth2.rfc6749.errors.InvalidClientIdError: (invalid_request) AADSTS90013: Invalid input received from the user.
...
>>> # but using the data argument works fine
>>> session.post('https://...', data=json.dumps(data_obj))
```
This commit add the json argument to theOAuth2Session.request, prevent json argument being captured into **kwargs and pass to the OAuth2Session.refresh_token.

The commit has passed the unittest and my own test.