### PR TITLE
Remove client_id and client_secret from body (generated via prepare_r…

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -192,16 +192,12 @@ class OAuth2Session(requests.Session):
                 raise ValueError('Please supply either code or '
                                  'authorization_response parameters.')
 
-
-        body = self._client.prepare_request_body(code=code, body=body,
-                redirect_uri=self.redirect_uri, username=username,
-                password=password, **kwargs)
-
-        client_id = kwargs.get('client_id', '')
         if auth is None:
+            client_id = kwargs.pop('client_id', '')
+
             if client_id:
                 log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
-                client_secret = kwargs.get('client_secret', '')
+                client_secret = kwargs.pop('client_secret', '')
                 client_secret = client_secret if client_secret is not None else ''
                 auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
             elif username:
@@ -209,6 +205,10 @@ class OAuth2Session(requests.Session):
                     raise ValueError('Username was supplied, but not password.')
                 log.debug('Encoding username, password as Basic auth credentials.')
                 auth = requests.auth.HTTPBasicAuth(username, password)
+
+        body = self._client.prepare_request_body(code=code, body=body,
+                                                 redirect_uri=self.redirect_uri, username=username,
+                                                 password=password, **kwargs)
 
         headers = headers or {
             'Accept': 'application/json',


### PR DESCRIPTION
Remove client_id and client_secret from body (generated via prepare_request_body) if HTTPBasicAuth used.

Usage:

token = oauth.fetch_token(
    token_url='token_url_here',
    code='code_here',
    client_id='client_id_here',
    client_secret='client_secret_here'
)