### PR TITLE
Move auth calculation into refresh_token method

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -282,6 +282,15 @@ class OAuth2Session(requests.Session):
         log.debug('Adding auto refresh key word arguments %s.',
                   self.auto_refresh_kwargs)
         kwargs.update(self.auto_refresh_kwargs)
+
+        auth = auth or kwargs.get('auth', None)
+        client_id = kwargs.get('client_id', None)
+        client_secret = kwargs.get('client_secret', '')
+
+        if client_id and (auth is None):
+            log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
+            auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
+
         body = self._client.prepare_refresh_body(body=body,
                 refresh_token=refresh_token, scope=self.scope, **kwargs)
         log.debug('Prepared refresh token request body %s', body)
@@ -312,8 +321,7 @@ class OAuth2Session(requests.Session):
             self.token['refresh_token'] = refresh_token
         return self.token
 
-    def request(self, method, url, data=None, headers=None, withhold_token=False,
-                client_id=None, client_secret='', **kwargs):
+    def request(self, method, url, data=None, headers=None, withhold_token=False, **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
         if not is_secure_transport(url):
             raise InsecureTransportError()
@@ -334,14 +342,7 @@ class OAuth2Session(requests.Session):
                     log.debug('Auto refresh is set, attempting to refresh at %s.',
                               self.auto_refresh_url)
 
-                    # We mustn't pass auth twice.
-                    auth = kwargs.pop('auth', None)
-                    if client_id and (auth is None):
-                        log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
-                        auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
-                    token = self.refresh_token(
-                        self.auto_refresh_url, auth=auth, **kwargs
-                    )
+                    token = self.refresh_token(self.auto_refresh_url, **kwargs)
                     if self.token_updater:
                         log.debug('Updating token to %s using %s.',
                                   token, self.token_updater)

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -283,8 +283,8 @@ class OAuth2Session(requests.Session):
                   self.auto_refresh_kwargs)
         kwargs.update(self.auto_refresh_kwargs)
 
-        auth = auth or kwargs.get('auth', None)
-        client_id = kwargs.get('client_id', None)
+        auth = auth or kwargs.get('auth')
+        client_id = kwargs.get('client_id')
         client_secret = kwargs.get('client_secret', '')
 
         if client_id and (auth is None):

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -313,7 +313,7 @@ class OAuth2Session(requests.Session):
         return self.token
 
     def request(self, method, url, data=None, headers=None, withhold_token=False,
-                client_id=None, client_secret=None, **kwargs):
+                client_id=None, client_secret='', **kwargs):
         """Intercept all requests and add the OAuth 2 token if present."""
         if not is_secure_transport(url):
             raise InsecureTransportError()
@@ -336,7 +336,7 @@ class OAuth2Session(requests.Session):
 
                     # We mustn't pass auth twice.
                     auth = kwargs.pop('auth', None)
-                    if client_id and client_secret and (auth is None):
+                    if client_id and (auth is None):
                         log.debug('Encoding client_id "%s" with client_secret as Basic auth credentials.', client_id)
                         auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
                     token = self.refresh_token(


### PR DESCRIPTION
I was using an endpoint with no `client_secret`. I couldn't pass `client_id` to the endpoint as Basic auth unless I provided it as an `auth` kwarg to each request. However if the `TokenExpiredError` was not raised, then this `auth` was passed through to the original request endpoint as it was not popped from kwargs (?overwriting the intended token auth).

Based on the docs it seems like I should be able to pass `client_id` through `auto_refresh_kwargs` (https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html). However currently `auth` does not consider `auto_refresh_kwargs` at all.

Changes assume that the intended behaviour is that the token refresh auth can be provided in `auto_refresh_kwargs` else in the request `kwargs`. And that a `client_secret` is not mandatory.

Note that `client_id` and `client_secret` would still be passed down from the request method as `kwargs`.

More generally,
- I don't think a `client_secret` should be **required** for token refresh by `client_id`
- I don't think `client_id` and `client_secret` should need to be provided in every request but rather be sourced at a session level (like `auto_refresh_kwargs`) or from the client itself.