### PR TITLE
Pin OAuthlib to avoid breakage with 3.0.0 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.0.0
-oauthlib[signedtoken]>=2.1.0
+oauthlib[signedtoken]>=2.1.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup(
     url='https://github.com/requests/requests-oauthlib',
     packages=['requests_oauthlib', 'requests_oauthlib.compliance_fixes'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    install_requires=['oauthlib>=2.1.0', 'requests>=2.0.0'],
-    extras_require={'rsa': ['oauthlib[rsa]>=2.1.0', 'requests>=2.0.0']},
+    install_requires=['oauthlib>=2.1.0,<3.0.0', 'requests>=2.0.0'],
+    extras_require={'rsa': ['oauthlib[rsa]>=2.1.0,<3.0.0', 'requests>=2.0.0']},
     license='ISC',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
We're going to release OAuthLib 3.0.0 soon, which contains some breaking changes.

This PR is to avoid problems before we are able to merge #331.
