### PR TITLE
Replace bare 'except:' with 'except Exception:'

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -24,7 +24,7 @@ def urldecode(body):
     """Parse query or json to python dictionary"""
     try:
         return _urldecode(body)
-    except:
+    except Exception:
         import json
         return json.loads(body)
 


### PR DESCRIPTION
Catching all exceptions is generally considered a bad practice under
most circumstances as it will also catch KeyboardInterrupt and
SystemExit. These special cases should be raised to the interpreter to
allow the Python process to exit.

This fix complies with pycodestyle's error code E722:

https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes

> do not use bare except, specify exception instead