### PR TITLE
Add Travis/tox CI testing for Python 3 and pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 cache: pip
@@ -6,6 +7,9 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - pypy2.7-6.0
+  - pypy3.5-6.0
 install:
   - pip install -r requirements.txt
   - pip install requests-mock

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     zip_safe=False,
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps=


### PR DESCRIPTION
As supported platforms, they should be tested regularly by CI.