### PR TITLE
Remove dependency of unmaintained nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .coverage
 MANIFEST
 coverage.xml
-nosetests.xml
 junit-report.xml
 pylint.txt
 toy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - pip install requests-mock
   - pip install coveralls
 script:
-  - coverage run --source=requests_oauthlib -m nose
+  - coverage run --source=requests_oauthlib -m unittest discover
 after_success:
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist = py27, py34, py35, py36, pypy
 [testenv]
 deps=
     -r{toxinidir}/requirements.txt
-    nose
     mock
     coveralls
     requests-mock
-commands= coverage run --source=requests_oauthlib -m nose
+commands= coverage run --source=requests_oauthlib -m unittest discover


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3,
2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will
> likely cease without a new person/team to take over maintainership.
> New projects should consider using Nose2, py.test, or just plain
> unittest/unittest2.

Simplify tests by using the stdlib unittest. One fewer dependency.