### PR TITLE
Fix invalid escape sequence in OAuth1Session docstring

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -255,7 +255,7 @@ class OAuth1Session(requests.Session):
         return add_params_to_uri(url, kwargs.items())
 
     def fetch_request_token(self, url, realm=None, **request_kwargs):
-        """Fetch a request token.
+        r"""Fetch a request token.
 
         This is the first step in the OAuth 1 workflow. A request token is
         obtained by making a signed post request to url. The token is then


### PR DESCRIPTION
Fixes error of the form:

```
  requests-oauthlib/requests_oauthlib/oauth1_session.py:282: DeprecationWarning: invalid escape sequence \*
```

These will deprecation warnings will become an exception in a future
version of Python.