### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/examples/fitbit.rst
+++ b/docs/examples/fitbit.rst
@@ -3,13 +3,13 @@
 Fitbit OAuth 2 (Mobile Application Flow) Tutorial
 =================================================
 
-This makes use of the Implicit Grant Flow to obtain an access token for the `Fitbit API`_. Register a new client application there with a callback URL, and have your client ID handy. Based on an `another example`_ of the Mobile Application Flow. 
+This makes use of the Implicit Grant Flow to obtain an access token for the `Fitbit API`_. Register a new client application there with a callback URL, and have your client ID handy. Based on an `another example`_ of the Mobile Application Flow.
 
 .. _`Fitbit API`: https://dev.fitbit.com/
 .. _`another example`: https://github.com/requests/requests-oauthlib/issues/104
 
 .. code-block:: pycon
-    
+
     >>> import requests
     >>> from requests_oauthlib import OAuth2Session
     >>> from oauthlib.oauth2 import MobileApplicationClient
@@ -34,7 +34,7 @@ This makes use of the Implicit Grant Flow to obtain an access token for the `Fit
     >>> fitbit.token_from_fragment(callback_url)
 
     # We can also store the token for use later.
-    >>> token = fitbit['token']     
+    >>> token = fitbit['token']
 
     # At this point, assuming nothing blew up, we can make calls to the API as normal, for example:
     >>> r = fitbit.get('https://api.fitbit.com/1/user/-/sleep/goal.json')

--- a/docs/examples/tumblr.rst
+++ b/docs/examples/tumblr.rst
@@ -1,7 +1,7 @@
 Tumblr OAuth1 Tutorial
 ======================
 
-Register a new application on the `tumblr application page`_. 
+Register a new application on the `tumblr application page`_.
 Enter a call back url (can just be http://www.tumblr.com/dashboard) and get the ``OAuth Consumer Key`` and ``Secret Key``.
 
 .. _`tumblr application page`: http://www.tumblr.com/oauth/apps
@@ -35,4 +35,3 @@ Enter a call back url (can just be http://www.tumblr.com/dashboard) and get the 
 
     >>> # Fetch a protected resource
     >>> print tumblr.get('http://api.tumblr.com/v2/user/dashboard')
-

--- a/docs/examples/wso2.rst
+++ b/docs/examples/wso2.rst
@@ -20,7 +20,7 @@ command line interactive example below.
     >>> #generate HTTPBasicAuth Header
     >>> basic_auth = HTTPBasicAuth(client_id, client_secret)
     >>> client = BackendApplicationClient(client_id=client_id)
-    
+
     >>> #start oauth session
     >>> oauth = OAuth2Session(client=client)
     >>> token = oauth.fetch_token(token_url=token_url,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ approximately like this:
         return redirect(authorization_url)
 
     @app.route("/callback")
-    def callback(): 
+    def callback():
         github = OAuth2Session(client_id, state=session['oauth_state'])
         token = github.fetch_token(token_url, client_secret=client_secret,
                                    authorization_response=request.url)
@@ -81,4 +81,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.