### PR TITLE
Drop redundant 'requests' in extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=['requests_oauthlib', 'requests_oauthlib.compliance_fixes'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=['oauthlib>=2.1.0,<3.0.0', 'requests>=2.0.0'],
-    extras_require={'rsa': ['oauthlib[rsa]>=2.1.0,<3.0.0', 'requests>=2.0.0']},
+    extras_require={'rsa': ['oauthlib[rsa]>=2.1.0,<3.0.0']},
     license='ISC',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Already included in `install_requires`, which are always included in the requirements. There is no need to list it a second time.