### PR TITLE
Remove testing workarounds for Python 2.6

### DIFF
--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -29,10 +29,6 @@ def fake_token(token):
 class OAuth2SessionTest(TestCase):
 
     def setUp(self):
-        # For python 2.6
-        if not hasattr(self, 'assertIn'):
-            self.assertIn = lambda a, b: self.assertTrue(a in b)
-
         self.token = {
             'token_type': 'Bearer',
             'access_token': 'asdfoiw37850234lkjsdfsdf',


### PR DESCRIPTION
Python 2.6 has not been supported since 84ad78ca24e323669a6ceea989390fd7ed9a11bf in the v1.0.0 release.