### PR TITLE
Use more specific asserts

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,7 +89,7 @@ class OAuth1Test(unittest.TestCase):
         oauth = requests_oauthlib.OAuth1('client_key')
 
         r = requests.get('http://httpbin.org/get', auth=oauth)
-        self.assertTrue(isinstance(r.request.url, str))
+        self.assertIsInstance(r.request.url, str)
 
     def test_content_type_override(self, generate_nonce, generate_timestamp):
         """
@@ -120,8 +120,8 @@ class OAuth1Test(unittest.TestCase):
 
         normal = requests_oauthlib.OAuth1('client_key')
 
-        self.assertTrue(isinstance(normal.client, oauthlib.oauth1.Client))
-        self.assertFalse(isinstance(normal.client, ClientSubclass))
+        self.assertIsInstance(normal.client, oauthlib.oauth1.Client)
+        self.assertNotIsInstance(normal.client, ClientSubclass)
 
         requests_oauthlib.OAuth1.client_class = ClientSubclass
 
@@ -129,11 +129,11 @@ class OAuth1Test(unittest.TestCase):
 
         custom = requests_oauthlib.OAuth1('client_key')
 
-        self.assertTrue(isinstance(custom.client, oauthlib.oauth1.Client))
-        self.assertTrue(isinstance(custom.client, ClientSubclass))
+        self.assertIsInstance(custom.client, oauthlib.oauth1.Client)
+        self.assertIsInstance(custom.client, ClientSubclass)
 
         overridden = requests_oauthlib.OAuth1('client_key',
             client_class = oauthlib.oauth1.Client)
 
-        self.assertTrue(isinstance(overridden.client, oauthlib.oauth1.Client))
-        self.assertFalse(isinstance(normal.client, ClientSubclass))
+        self.assertIsInstance(overridden.client, oauthlib.oauth1.Client)
+        self.assertNotIsInstance(normal.client, ClientSubclass)

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -152,8 +152,8 @@ class OAuth1SessionTest(unittest.TestCase):
         self.assertEqual(resp['oauth_token'], 'foo')
         self.assertEqual(resp['oauth_verifier'], 'bar')
         for k, v in resp.items():
-            self.assertTrue(isinstance(k, unicode_type))
-            self.assertTrue(isinstance(v, unicode_type))
+            self.assertIsInstance(k, unicode_type)
+            self.assertIsInstance(v, unicode_type)
 
     def test_fetch_request_token(self):
         auth = OAuth1Session('foo')
@@ -161,8 +161,8 @@ class OAuth1SessionTest(unittest.TestCase):
         resp = auth.fetch_request_token('https://example.com/token')
         self.assertEqual(resp['oauth_token'], 'foo')
         for k, v in resp.items():
-            self.assertTrue(isinstance(k, unicode_type))
-            self.assertTrue(isinstance(v, unicode_type))
+            self.assertIsInstance(k, unicode_type)
+            self.assertIsInstance(v, unicode_type)
 
     def test_fetch_request_token_with_optional_arguments(self):
         auth = OAuth1Session('foo')
@@ -171,8 +171,8 @@ class OAuth1SessionTest(unittest.TestCase):
                                         verify=False, stream=True)
         self.assertEqual(resp['oauth_token'], 'foo')
         for k, v in resp.items():
-            self.assertTrue(isinstance(k, unicode_type))
-            self.assertTrue(isinstance(v, unicode_type))
+            self.assertIsInstance(k, unicode_type)
+            self.assertIsInstance(v, unicode_type)
 
     def test_fetch_access_token(self):
         auth = OAuth1Session('foo', verifier='bar')
@@ -180,8 +180,8 @@ class OAuth1SessionTest(unittest.TestCase):
         resp = auth.fetch_access_token('https://example.com/token')
         self.assertEqual(resp['oauth_token'], 'foo')
         for k, v in resp.items():
-            self.assertTrue(isinstance(k, unicode_type))
-            self.assertTrue(isinstance(v, unicode_type))
+            self.assertIsInstance(k, unicode_type)
+            self.assertIsInstance(v, unicode_type)
 
     def test_fetch_access_token_with_optional_arguments(self):
         auth = OAuth1Session('foo', verifier='bar')
@@ -190,8 +190,8 @@ class OAuth1SessionTest(unittest.TestCase):
                                        verify=False, stream=True)
         self.assertEqual(resp['oauth_token'], 'foo')
         for k, v in resp.items():
-            self.assertTrue(isinstance(k, unicode_type))
-            self.assertTrue(isinstance(v, unicode_type))
+            self.assertIsInstance(k, unicode_type)
+            self.assertIsInstance(v, unicode_type)
 
     def _test_fetch_access_token_raises_error(self, auth):
         """Assert that an error is being raised whenever there's no verifier
@@ -261,7 +261,7 @@ class OAuth1SessionTest(unittest.TestCase):
 
     def test_authorized_false(self):
         sess = OAuth1Session('foo')
-        self.assertFalse(sess.authorized)
+        self.assertIs(sess.authorized, False)
 
     def test_authorized_false_rsa(self):
         signature = ('OAuth '
@@ -272,13 +272,13 @@ class OAuth1SessionTest(unittest.TestCase):
         sess = OAuth1Session('foo', signature_method=SIGNATURE_RSA,
                              rsa_key=TEST_RSA_KEY)
         sess.send = self.verify_signature(signature)
-        self.assertFalse(sess.authorized)
+        self.assertIs(sess.authorized, False)
 
     def test_authorized_true(self):
         sess = OAuth1Session('key', 'secret', verifier='bar')
         sess.send = self.fake_body('oauth_token=foo&oauth_token_secret=bar')
         sess.fetch_access_token('https://example.com/token')
-        self.assertTrue(sess.authorized)
+        self.assertIs(sess.authorized, True)
 
     @mock.patch('oauthlib.oauth1.rfc5849.generate_timestamp')
     @mock.patch('oauthlib.oauth1.rfc5849.generate_nonce')
@@ -297,7 +297,7 @@ class OAuth1SessionTest(unittest.TestCase):
                              rsa_key=TEST_RSA_KEY, verifier='bar')
         sess.send = self.fake_body('oauth_token=foo&oauth_token_secret=bar')
         sess.fetch_access_token('https://example.com/token')
-        self.assertTrue(sess.authorized)
+        self.assertIs(sess.authorized, True)
 
     def verify_signature(self, signature):
         def fake_send(r, **kwargs):

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -221,7 +221,7 @@ class OAuth2SessionTest(TestCase):
 
     def test_authorized_false(self):
         sess = OAuth2Session('foo')
-        self.assertFalse(sess.authorized)
+        self.assertIs(sess.authorized, False)
 
     @mock.patch("time.time", new=lambda: fake_time)
     def test_authorized_true(self):
@@ -236,6 +236,6 @@ class OAuth2SessionTest(TestCase):
         for client in self.clients:
             sess = OAuth2Session(client=client)
             sess.send = fake_token(self.token)
-            self.assertFalse(sess.authorized)
+            self.assertIs(sess.authorized, False)
             sess.fetch_token(url)
-            self.assertTrue(sess.authorized)
+            self.assertIs(sess.authorized, True)


### PR DESCRIPTION
More specific asserts generally result in more informative error
messages when tests fail. This practice is recommended by the unittest
docs:

https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertTrue

> This method should also be avoided when more specific methods are
> available (e.g. assertEqual(a, b) instead of assertTrue(a == b)),
> because they provide a better error message in case of failure.

Replace assertTrue(isinstance(...)) with assertIsInstance.

Additionally, replace truthiness checks with precise True/False checks.
This practice is also recommended by the unittest docs:

> assertTrue
>
> Note that this is equivalent to bool(expr) is True and not to expr is
> True (use assertIs(expr, True) for the latter).

Replace assertTrue(...) with assertIs(..., True).