### PR TITLE
Correct dependency for 'rsa' extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=['requests_oauthlib', 'requests_oauthlib.compliance_fixes'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=['oauthlib>=2.1.0,<3.0.0', 'requests>=2.0.0'],
-    extras_require={'rsa': ['oauthlib[rsa]>=2.1.0,<3.0.0']},
+    extras_require={'rsa': ['oauthlib[signedtoken]>=2.1.0,<3.0.0']},
     license='ISC',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     cryptography = None
 
+try:
+    import jwt
+except ImportError:
+    jwt = None
+
 if sys.version[0] == '3':
     unicode_type = str
 else:
@@ -92,6 +97,8 @@ class OAuth1SessionTest(unittest.TestCase):
     def test_signature_methods(self, generate_nonce, generate_timestamp):
         if not cryptography:
             raise unittest.SkipTest('cryptography module is required')
+        if not jwt:
+            raise unittest.SkipTest('pyjwt module is required')
 
         generate_nonce.return_value = 'abc'
         generate_timestamp.return_value = '123'
@@ -285,6 +292,8 @@ class OAuth1SessionTest(unittest.TestCase):
     def test_authorized_true_rsa(self, generate_nonce, generate_timestamp):
         if not cryptography:
             raise unittest.SkipTest('cryptography module is required')
+        if not jwt:
+            raise unittest.SkipTest('pyjwt module is required')
 
         generate_nonce.return_value = 'abc'
         generate_timestamp.return_value = '123'


### PR DESCRIPTION
The RSA tests only pass if `oauthlib[signedtoken]` is installed. `oauthlib[rsa]` is not enough. This brings the dependency in line with the `requirements.txt` file. Skip the test if pyjwt is not installed to avoid a test failure due to an `ImportError`.