### PR TITLE
add instagram compliance fix

### DIFF
--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -4,6 +4,7 @@ from .facebook import facebook_compliance_fix
 from .fitbit import fitbit_compliance_fix
 from .linkedin import linkedin_compliance_fix
 from .slack import slack_compliance_fix
+from .instagram import instagram_compliance_fix
 from .mailchimp import mailchimp_compliance_fix
 from .weibo import weibo_compliance_fix
 from .plentymarkets import plentymarkets_compliance_fix

--- a/requests_oauthlib/compliance_fixes/instagram.py
+++ b/requests_oauthlib/compliance_fixes/instagram.py
@@ -8,15 +8,12 @@ from oauthlib.common import add_params_to_uri
 
 def instagram_compliance_fix(session):
     def _non_compliant_param_name(url, headers, data):
-        # If the user has already specified the token, either in the URL
-        # or in a data dictionary, then there's nothing to do.
+        # If the user has already specified the token in the URL
+        # then there's nothing to do.
         # If the specified token is different from ``session.access_token``,
         # we assume the user intends to override the access token.
         url_query = dict(parse_qs(urlparse(url).query))
-        token = url_query.get("token")
-        if not token and isinstance(data, dict):
-            token = data.get("token")
-
+        token = url_query.get("access_token")
         if token:
             # Nothing to do, just return.
             return url, headers, data

--- a/requests_oauthlib/compliance_fixes/instagram.py
+++ b/requests_oauthlib/compliance_fixes/instagram.py
@@ -1,0 +1,30 @@
+try:
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlparse, parse_qs
+
+from oauthlib.common import add_params_to_uri
+
+
+def instagram_compliance_fix(session):
+    def _non_compliant_param_name(url, headers, data):
+        # If the user has already specified the token, either in the URL
+        # or in a data dictionary, then there's nothing to do.
+        # If the specified token is different from ``session.access_token``,
+        # we assume the user intends to override the access token.
+        url_query = dict(parse_qs(urlparse(url).query))
+        token = url_query.get("token")
+        if not token and isinstance(data, dict):
+            token = data.get("token")
+
+        if token:
+            # Nothing to do, just return.
+            return url, headers, data
+
+        token = [('access_token', session.access_token)]
+        url = add_params_to_uri(url, token)
+        return url, headers, data
+
+    session.register_compliance_hook(
+        'protected_request', _non_compliant_param_name)
+    return session


### PR DESCRIPTION
- [x] add tests

Instagram requires access_token to be inserted in the URL of the requests as stated here: https://www.instagram.com/developer/endpoints/.