### PR TITLE
Fix for Python 4: use sys.version_info[0] >= 3 instead of sys.version == "3"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 cache: pip
 python:

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     jwt = None
 
-if sys.version[0] == "3":
+if sys.version_info[0] >= 3:
     unicode_type = str
 else:
     unicode_type = unicode


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

It's not safe to compare the major version number to 3, it'll end up running Python 2 code when Python 4 is out.

Also, not a problem until Python 10 (!), but might as well fix it too: use the `sys.version_info` tuple instead of assuming `sys.version` is always a single-length character.

---

Additionally, `sudo:` is no longer needed https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration