### PR TITLE
Add support for auto-refreshing token without refresh token

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -41,6 +41,7 @@ class OAuth2Session(requests.Session):
         client=None,
         auto_refresh_url=None,
         auto_refresh_kwargs=None,
+        auto_refresh_type="refresh_token",
         scope=None,
         redirect_uri=None,
         token=None,
@@ -67,6 +68,8 @@ class OAuth2Session(requests.Session):
                            your access tokens.
         :auto_refresh_kwargs: Extra arguments to pass to the refresh token
                               endpoint.
+        :auto_refresh_type: Type of auto refresh method to use.  Must be either
+                            "refresh_token" (default) or "access_token".
         :token_updater: Method with one argument, token, to be used to update
                         your token database on automatic token refresh. If not
                         set a TokenUpdated warning will be raised when a token
@@ -83,6 +86,7 @@ class OAuth2Session(requests.Session):
         self._state = state
         self.auto_refresh_url = auto_refresh_url
         self.auto_refresh_kwargs = auto_refresh_kwargs or {}
+        self.auto_refresh_type = auto_refresh_type
         self.token_updater = token_updater
 
         # Ensure that requests doesn't do any automatic auth. See #278.
@@ -499,9 +503,18 @@ class OAuth2Session(requests.Session):
                             client_id,
                         )
                         auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
-                    token = self.refresh_token(
-                        self.auto_refresh_url, auth=auth, **kwargs
-                    )
+                    if self.auto_refresh_type == "refresh_token":
+                        token = self.refresh_token(
+                            self.auto_refresh_url, auth=auth, **kwargs
+                        )
+                    elif self.auto_refresh_type == "access_token":
+                        token = self.fetch_token(
+                            self.auto_refresh_url,
+                            auth=auth,
+                            **dict(kwargs, **self.auto_refresh_kwargs),
+                        )
+                    else:
+                        raise RuntimeError("Unknown auto_refresh_type: %s" % self.auto_refresh_type)
                     if self.token_updater:
                         log.debug(
                             "Updating token to %s using %s.", token, self.token_updater


### PR DESCRIPTION
This is a basic idea on how to fix #260 since nothing has happened to the issue in three years. Let's get a discussion going, because this is a hindrance to me in almost every OAuth2 implementation I make using this library and it's clear that lots of other people have the same issue.

So the idea is to add a new constructor parameter which I currently call `auto_refresh_type`, it can be either `"refresh_token"` (which will do exactly what it does today) or `"access_token"` (which will just get a new access token as you normally do).

It's not a beautiful design by any means, but I intentionally tried to keep the diff as minimal as possible without any major refactorings, which would introduce breaking changes and make it more difficult to get this functionality out there.