### PR TITLE
Don't pass 'files' through to token refresh

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -464,6 +464,7 @@ class OAuth2Session(requests.Session):
         withhold_token=False,
         client_id=None,
         client_secret=None,
+        files=None,
         **kwargs
     ):
         """Intercept all requests and add the OAuth 2 token if present."""
@@ -519,7 +520,7 @@ class OAuth2Session(requests.Session):
         log.debug("Supplying headers %s and data %s", headers, data)
         log.debug("Passing through key word arguments %s.", kwargs)
         return super(OAuth2Session, self).request(
-            method, url, headers=headers, data=data, **kwargs
+            method, url, headers=headers, data=data, files=files, **kwargs
         )
 
     def register_compliance_hook(self, hook_type, hook):


### PR DESCRIPTION
When using the `files` parameter in requests for multipart file uploads, and a token needs to be refreshed, the `files` are passed along with the refresh token request.

This pull request only passes `files` to the actual request (as is the case with `data`).