### PR TITLE
Update documentation for Python 3

### DIFF
--- a/docs/examples/outlook.rst
+++ b/docs/examples/outlook.rst
@@ -30,7 +30,7 @@ a callback URL then you can try out the command line interactive example below.
     >>> redirect_response = input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
-    >>> token = outlook.fetch_token(token_url,client_secret=client_secret,authorization_response=redirect_response)
+    >>> token = outlook.fetch_token(token_url, client_secret=client_secret, authorization_response=redirect_response)
 
     >>> # Fetch a protected resource, i.e. calendar information
     >>> o = outlook.get('https://outlook.office.com/api/v1.0/me/calendars')

--- a/docs/examples/outlook.rst
+++ b/docs/examples/outlook.rst
@@ -24,14 +24,14 @@ a callback URL then you can try out the command line interactive example below.
 
     >>> # Redirect  the user owner to the OAuth provider (i.e. Outlook) using an URL with a few key OAuth parameters.
     >>> authorization_url, state = outlook.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print('Please go here and authorize,', authorization_url)
 
     >>> # Get the authorization verifier code from the callback url
-    >>> redirect_response = raw_input('Paste the full redirect URL here:')
+    >>> redirect_response = input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
     >>> token = outlook.fetch_token(token_url,client_secret=client_secret,authorization_response=redirect_response)
 
     >>> # Fetch a protected resource, i.e. calendar information
     >>> o = outlook.get('https://outlook.office.com/api/v1.0/me/calendars')
-    >>> print o.content
+    >>> print(o.content)


### PR DESCRIPTION
Given that Python 2 is out of support, the documenation examples should probably use Python 3 syntax (i.e. print as a function, input instead of raw_input) instead of Python 2 syntax.