### PR TITLE
Fix for #437 - remove erroneous charset param from Content-Type header

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -325,7 +325,7 @@ class OAuth2Session(requests.Session):
 
         headers = headers or {
             "Accept": "application/json",
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
         self.token = {}
         request_kwargs = {}
@@ -426,7 +426,7 @@ class OAuth2Session(requests.Session):
         if headers is None:
             headers = {
                 "Accept": "application/json",
-                "Content-Type": ("application/x-www-form-urlencoded;charset=UTF-8"),
+                "Content-Type": ("application/x-www-form-urlencoded"),
             }
 
         r = self.post(


### PR DESCRIPTION
The WHATWG URL Standard [unambiguously defines the `application/x-www-form-urlencoded` format, its parsing and encoding (which includes UTF-8, but applies additional steps)](https://url.spec.whatwg.org/#application/x-www-form-urlencoded). Consequently, no charset is required, or indeed permitted, with the `application/x-www-form-urlencoded` content type, and supplying one causes issues with some authorization servers.