### PR TITLE
Add Python 3.8 & 3.9 as supported versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,10 @@ jobs:
             tox-env: py36
           - python-version: 3.7
             tox-env: py37,docs,readme,black
+          - python-version: 3.8
+            tox-env: py38
+          - python-version: 3.9
+            tox-env: py39
           - python-version: pypy3
             tox-env: pypy3
     steps:

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,pypy,pypy3,docs,readme,black
+envlist=py27,py34,py35,py36,py37,py38,py39,pypy,pypy3,docs,readme,black
 
 [testenv]
 deps=


### PR DESCRIPTION
Since Py 3.8 is supported, we should update the "classifiers", as it is shown on PyPI and gives wrong impressions that Py 3.8 is not supported.

This PR also adds Py 3.9 and adds them to CI