### PR TITLE
oauth2-session - Allow Scope to be mutable

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -390,6 +390,7 @@ class OAuth2Session(requests.Session):
         headers=None,
         verify=True,
         proxies=None,
+        scope=self.scope,
         **kwargs
     ):
         """Fetch a new access token using a refresh token.
@@ -403,6 +404,8 @@ class OAuth2Session(requests.Session):
         :param headers: A dict of headers to be used by `requests`.
         :param verify: Verify SSL certificate.
         :param proxies: The `proxies` argument will be passed to `requests`.
+        :param scope: The scope of the refreshed token, 
+                      Must be None, equal to, or a subset of the original token
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict
         """
@@ -419,7 +422,7 @@ class OAuth2Session(requests.Session):
         )
         kwargs.update(self.auto_refresh_kwargs)
         body = self._client.prepare_refresh_body(
-            body=body, refresh_token=refresh_token, scope=self.scope, **kwargs
+            body=body, refresh_token=refresh_token, scope=scope, **kwargs
         )
         log.debug("Prepared refresh token request body %s", body)
 

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -230,9 +230,9 @@ class OAuth2Session(requests.Session):
                               `auth` tuple. If the value is `None`, it will be
                               omitted from the request, however if the value is
                               an empty string, an empty string will be sent.
-        :param cert: Client certificate to send for OAuth 2.0 Mutual-TLS Client 
-                     Authentication (draft-ietf-oauth-mtls). Can either be the 
-                     path of a file containing the private key and certificate or 
+        :param cert: Client certificate to send for OAuth 2.0 Mutual-TLS Client
+                     Authentication (draft-ietf-oauth-mtls). Can either be the
+                     path of a file containing the private key and certificate or
                      a tuple of two filenames for certificate and key.
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict
@@ -404,7 +404,7 @@ class OAuth2Session(requests.Session):
         :param headers: A dict of headers to be used by `requests`.
         :param verify: Verify SSL certificate.
         :param proxies: The `proxies` argument will be passed to `requests`.
-        :param scope: The scope of the refreshed token, 
+        :param scope: The scope of the refreshed token,
                       Must be None, equal to, or a subset of the original token
         :param kwargs: Extra parameters to include in the token request.
         :return: A token dict

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -390,7 +390,7 @@ class OAuth2Session(requests.Session):
         headers=None,
         verify=True,
         proxies=None,
-        scope=self.scope,
+        scope=1,
         **kwargs
     ):
         """Fetch a new access token using a refresh token.
@@ -421,6 +421,8 @@ class OAuth2Session(requests.Session):
             "Adding auto refresh key word arguments %s.", self.auto_refresh_kwargs
         )
         kwargs.update(self.auto_refresh_kwargs)
+        if scope == 1:
+            scope = self.scope
         body = self._client.prepare_refresh_body(
             body=body, refresh_token=refresh_token, scope=scope, **kwargs
         )


### PR DESCRIPTION
Some API's do not allow for scope to be submitted in the refresh token.