### PR TITLE
Fix Docs generation - Improve Pipeline

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+sphinx:
+   configuration: docs/conf.py
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,14 @@ build:
   tools:
     python: "3.7"
 sphinx:
-   configuration: docs/conf.py
-# Optionally declare the Python requirements required to build your docs
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true
+# the requirements.txt override some RTD defaults.
+# ideally it has to be updated from time to time
+# with latest libraries versions.
 python:
    install:
    - requirements: docs/requirements.txt
+   - method: setuptools
+     path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  # fail_on_warning: true
 # the requirements.txt override some RTD defaults.
 # ideally it has to be updated from time to time
 # with latest libraries versions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
-dist: xenial
+dist: bionic
 sudo: false
 language: python
 cache: pip
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
-  - pypy2.7-6.0
-  - pypy3.5-6.0
-install:
-  - pip install -r requirements.txt
-  - pip install requests-mock
-  - pip install coveralls
-script:
-  - coverage run --source=requests_oauthlib -m unittest discover
-after_success:
-  - coveralls
-
 matrix:
   include:
-  - name: "Black"
-    python: 3.7
-    install: travis_retry pip install black
-    script: black --check .
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 3.4
+    env: TOXENV=py34
+  - python: 3.5
+    env: TOXENV=py35
+  - python: 3.6
+    env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37,docs,readme
+  - python: 3.7
+    env: TOXENV=black
     after_success: skip
+  - python: pypy2.7-6.0
+    env: TOXENV=pypy
+  - python: pypy3.5-6.0
+    env: TOXENV=pypy3
+before_install:
+  - python -m pip install --upgrade pip setuptools
+  - python -m pip install tox coveralls
+  script:
+  - tox
+after_success:
+  - COVERALLS_PARALLEL=true coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ html_theme = "default"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-sphinx
-docutils<=0.15
-sphinx_rtd_theme
+sphinx<2
+docutils<=0.15  # docutils 0.16 has an error when generating in api.rst
+sphinx_rtd_theme<0.5
+readthedocs-sphinx-ext

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+docutils<=0.15
+sphinx_rtd_theme

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+coveralls==3.2.0
+mock==4.0.3
+requests-mock==1.9.3

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,2 @@
+requests>=2.0.0
+oauthlib[signedtoken]>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=2.0.0
-oauthlib[signedtoken]>=3.0.0
+requests==2.26.0
+oauthlib[signedtoken]==3.1.1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     version=VERSION,
     description="OAuthlib authentication support for Requests.",
     long_description=readall("README.rst") + "\n\n" + readall("HISTORY.rst"),
+    long_description_content_type="text/x-rst",
     author="Kenneth Reitz",
     author_email="me@kennethreitz.com",
     url="https://github.com/requests/requests-oauthlib",

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ basepython=python3.7
 skipsdist=True
 # docutils 0.16 has an error when generating in api.rst
 deps=
-        sphinx
-        docutils<=0.15
-        sphinx_rtd_theme
+    -r{toxinidir}/docs/requirements.txt
 changedir=docs
 whitelist_externals=make
 commands=make clean html

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@ deps=
 commands=coverage run --source=requests_oauthlib -m unittest discover
 
 # tox -e docs to mimick readthedocs build.
+# should be similar to .readthedocs.yaml pipeline
 [testenv:docs]
 basepython=python3.7
 skipsdist=True
-# docutils 0.16 has an error when generating in api.rst
 deps=
     -r{toxinidir}/docs/requirements.txt
 changedir=docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,19 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3, docs, readme
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, docs, readme, black
 
 [testenv]
 deps=
-    -r{toxinidir}/requirements.txt
-    mock
-    coveralls
-    requests-mock
+    -r{toxinidir}/requirements-test.txt
 commands= coverage run --source=requests_oauthlib -m unittest discover
 
 # tox -e docs to mimick readthedocs build.
 [testenv:docs]
 basepython=python3.7
 skipsdist=True
+# docutils 0.16 has an error when generating in api.rst
 deps=
         sphinx
+        docutils<=0.15
         sphinx_rtd_theme
 changedir=docs
 whitelist_externals=make
@@ -26,3 +25,8 @@ basepython=python3.7
 deps=twine>=1.12.0
 commands=
         twine check .tox/dist/*
+
+[testenv:black]
+basepython=python3.7
+deps=black
+commands=black --check .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, docs, readme
 
 [testenv]
 deps=
@@ -8,3 +8,21 @@ deps=
     coveralls
     requests-mock
 commands= coverage run --source=requests_oauthlib -m unittest discover
+
+# tox -e docs to mimick readthedocs build.
+[testenv:docs]
+basepython=python3.7
+skipsdist=True
+deps=
+        sphinx
+        sphinx_rtd_theme
+changedir=docs
+whitelist_externals=make
+commands=make clean html
+
+# tox -e readme to mimick pypi validation of readme/rst files.
+[testenv:readme]
+basepython=python3.7
+deps=twine>=1.12.0
+commands=
+        twine check .tox/dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3, docs, readme, black
+envlist=py27,py34,py35,py36,py37,pypy,pypy3,docs,readme,black
 
 [testenv]
 deps=
     -r{toxinidir}/requirements-test.txt
-commands= coverage run --source=requests_oauthlib -m unittest discover
+commands=coverage run --source=requests_oauthlib -m unittest discover
 
 # tox -e docs to mimick readthedocs build.
 [testenv:docs]


### PR DESCRIPTION
Add docs generation into tox. Took the opportunity to move Black Travis job into Tox as well.

To generate Sphinx (ReadTheDocs) locally, you can run `tox -e docs`
To validate Readme syntax (used when publishing package into Pypi https://pypi.org/project/requests-oauthlib/ ), you can run `tox -e readme`
To validate code syntax, you can run `tox -e black` 

Also fix https://github.com/requests/requests-oauthlib/issues/392 by adding a docutils 0.16 restriction which is blocking ReadTheDocs worker.