### PR TITLE
Fix Sphinx error for oauth1 fetch_token documentation

### DIFF
--- a/docs/examples/outlook.rst
+++ b/docs/examples/outlook.rst
@@ -1,5 +1,5 @@
 Outlook Calendar OAuth 2 Tutorial
-==========================
+=================================
 
 Create a new web application client in the `Microsoft Application Registration Portal`_
 When you have obtained a ``client_id``, ``client_secret`` and registered

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -268,7 +268,7 @@ class OAuth1Session(requests.Session):
         :param url: The request token endpoint URL.
         :param realm: A list of realms to request access to.
         :param \*\*request_kwargs: Optional arguments passed to ''post''
-        function in ''requests.Session''
+            function in ''requests.Session''
         :returns: The response in dict format.
 
         Note that a previously set callback_uri will be reset for your


### PR DESCRIPTION
Fix https://requests-oauthlib.readthedocs.io/en/v1.3.0-docs/api.html#requests_oauthlib.OAuth1Session.fetch_request_token
docstring issue resulting in an absent "returns" field.