### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,17 +11,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 2.7
+          - python-version: "2.7"
             tox-env: py27
-          - python-version: 3.6
+          - python-version: "3.6"
             tox-env: py36
-          - python-version: 3.7
+          - python-version: "3.7"
             tox-env: py37,docs,readme,black
-          - python-version: 3.8
+          - python-version: "3.8"
             tox-env: py38
-          - python-version: 3.9
+          - python-version: "3.9"
             tox-env: py39
-          - python-version: pypy3
+          - python-version: "3.10"
+            tox-env: py310
+          - python-version: "pypy3"
             tox-env: pypy3
     steps:
     - uses: actions/checkout@v2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Patches and Suggestions
 - kracekumar <me@kracekumar.com>
 - David Baumgold <david@davidbaumgold.com>
 - Craig Anderson <craiga@craiga.id.au>
+- Hugo van Kemenade <https://github.com/hugovk>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
 - Add initial support for OAuth Mutual TLS (draft-ietf-oauth-mtls)
 - Removed outdated LinkedIn Compliance Fixes
+- Add support for Python 3.8-3.10
 
 v1.3.0 (6 November 2019)
 ++++++++++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39,pypy,pypy3,docs,readme,black
+envlist=py27,py34,py35,py36,py37,py38,py39,py310,pypy,pypy3,docs,readme,black
 
 [testenv]
 deps=


### PR DESCRIPTION
Follow on from https://github.com/requests/requests-oauthlib/issues/443 / https://github.com/requests/requests-oauthlib/pull/442.

Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955