### PR TITLE
Updates docs in oauth_session1 to match existing pattern

### DIFF
--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -33,6 +33,7 @@ class TokenRequestDenied(ValueError):
         super(TokenRequestDenied, self).__init__(message)
         self.response = response
 
+    @property
     def status_code(self):
         """For backwards-compatibility purposes"""
         return self.response.status_code
@@ -170,6 +171,7 @@ class OAuth1Session(requests.Session):
         )
         self.auth = self._client
 
+    @property
     def token(self):
         oauth_token = self._client.client.resource_owner_key
         oauth_token_secret = self._client.client.resource_owner_secret
@@ -189,6 +191,7 @@ class OAuth1Session(requests.Session):
     def token(self, value):
         self._populate_attributes(value)
 
+    @property
     def authorized(self):
         """Boolean that indicates whether this session has an OAuth token
         or not. If `self.authorized` is True, you can reasonably expect
@@ -255,7 +258,7 @@ class OAuth1Session(requests.Session):
         return add_params_to_uri(url, kwargs.items())
 
     def fetch_request_token(self, url, realm=None, **request_kwargs):
-        r"""Fetch a request token.
+        """Fetch a request token.
 
         This is the first step in the OAuth 1 workflow. A request token is
         obtained by making a signed post request to url. The token is then

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -33,7 +33,6 @@ class TokenRequestDenied(ValueError):
         super(TokenRequestDenied, self).__init__(message)
         self.response = response
 
-    @property
     def status_code(self):
         """For backwards-compatibility purposes"""
         return self.response.status_code
@@ -171,7 +170,6 @@ class OAuth1Session(requests.Session):
         )
         self.auth = self._client
 
-    @property
     def token(self):
         oauth_token = self._client.client.resource_owner_key
         oauth_token_secret = self._client.client.resource_owner_secret
@@ -191,7 +189,6 @@ class OAuth1Session(requests.Session):
     def token(self, value):
         self._populate_attributes(value)
 
-    @property
     def authorized(self):
         """Boolean that indicates whether this session has an OAuth token
         or not. If `self.authorized` is True, you can reasonably expect

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -267,7 +267,7 @@ class OAuth1Session(requests.Session):
 
         :param url: The request token endpoint URL.
         :param realm: A list of realms to request access to.
-        :param \*\*request_kwargs: Optional arguments passed to ''post''
+        :param request_kwargs: Optional arguments passed to ''post''
             function in ''requests.Session''
         :returns: The response in dict format.
 


### PR DESCRIPTION
## Notice
Accidentally closed last PR - trying to work out why coverage decreases by -0.0 percent when running coveralls with python version 3.7> 

## Original Description
Related to discussion on #473 #443 #442

Looks like all the uncertainty stems from a slight break for the existing documentation convention/pattern. Method documentation for, fetch_request_token in requests_oauthlib/oauth1_session.py added the double asterisk to the optional argument in the function description. The existing pattern is to add them for the signature and leave them off in the description. Before the doc string was flagged as a raw string, this was generating a warning for Invalid Escape Sequence.

Removing the raw string flag and the asterisks as it breaks the pattern already set.