### PR TITLE
Fix typo in PyPI package name in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ To install requests and requests_oauthlib you can use pip:
 
 .. code-block:: bash
 
-    $ pip install requests requests_oauthlib
+    $ pip install requests requests-oauthlib
 
 .. |build-status| image:: https://github.com/requests/requests-oauthlib/actions/workflows/run-tests.yml/badge.svg
    :target: https://github.com/requests/requests-oauthlib/actions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Installation
 
 Requests-OAuthlib can be installed with `pip <https://pip.pypa.io/>`_: ::
 
-    $ pip install requests_oauthlib
+    $ pip install requests-oauthlib
 
 
 Getting Started:


### PR DESCRIPTION
The official name of the package in PyPI appears to be [requests-oauthlib](https://pypi.org/project/requests-oauthlib/), with a dash rather than an underscore. Upon further testing it does look like `requests_oauthlib` also works, as this issues a HTTP 301 (Moved Permanently) to the version with the dash, so this change isn't strictly necessary, but it seems like a good idea for the documentation to point at the canonical name of the package in PyPI. Feel free to close without merging if you disagree. My feelings won't be hurt.