### PR TITLE
Revert 397 and add Deprecation warning instead

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ Patches and Suggestions
 - Sylvain Marie <sylvain.marie@se.com>
 - Craig Anderson <craiga@craiga.id.au>
 - Hugo van Kemenade <https://github.com/hugovk>
+- Jacques Troussard <https://developerslifefor.me>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,13 @@ v1.4.0 (TBD)
   is provided and ``scope`` is not overridden. Fixes `#408
   <https://github.com/requests/requests-oauthlib/issues/408>`_
 - Add support for Python 3.8-3.10
+- Remove Linkedin compliance fix.
 
+
+v1.3.2 (20 February 2022)
++++++++++++++++++++++++++
+
+- Revert Linkined compliances fix, add deprecation warning.
 
 v1.3.1 (21 January 2022)
 ++++++++++++++++++++++++

--- a/docs/examples/linkedin.rst
+++ b/docs/examples/linkedin.rst
@@ -9,41 +9,31 @@ command line interactive example below.
 
 .. code-block:: pycon
 
-    >>> # Imports
-    >>> import os
-    >>> from requests_oauthlib import OAuth2Session
-
-    >>> # Set environment variables
-    >>> os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
-
     >>> # Credentials you get from registering a new application
     >>> client_id = '<the id you get from linkedin>'
     >>> client_secret = '<the secret you get from linkedin>'
 
-    >>> # LinkedIn OAuth2 requests require scope and redirect_url parameters.
-    >>> # Ensure these values match the auth values in your LinkedIn App 
-    >>> # (see auth tab on LinkedIn Developer page)
-    >>> scope = ['r_liteprofile']
-    >>> redirect_url = 'http://127.0.0.1'
-
     >>> # OAuth endpoints given in the LinkedIn API documentation
-    >>> authorization_base_url = 'https://www.linkedin.com/oauth/v2/authorization'
-    >>> token_url = 'https://www.linkedin.com/oauth/v2/accessToken'
+    >>> authorization_base_url = 'https://www.linkedin.com/uas/oauth2/authorization'
+    >>> token_url = 'https://www.linkedin.com/uas/oauth2/accessToken'
 
-    >>> linkedin = OAuth2Session(client_id, redirect_uri='http://127.0.0.1', scope=scope)
+    >>> from requests_oauthlib import OAuth2Session
+    >>> from requests_oauthlib.compliance_fixes import linkedin_compliance_fix
+
+    >>> linkedin = OAuth2Session(client_id, redirect_uri='http://127.0.0.1')
+    >>> linkedin = linkedin_compliance_fix(linkedin)
 
     >>> # Redirect user to LinkedIn for authorization
     >>> authorization_url, state = linkedin.authorization_url(authorization_base_url)
-    >>> print(f"Please go here and authorize: {authorization_url}")
+    >>> print 'Please go here and authorize,', authorization_url
 
     >>> # Get the authorization verifier code from the callback url
-    >>> redirect_response = input('Paste the full redirect URL here:')
+    >>> redirect_response = raw_input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
     >>> linkedin.fetch_token(token_url, client_secret=client_secret,
-    ...                      include_client_id=True,
     ...                      authorization_response=redirect_response)
 
     >>> # Fetch a protected resource, i.e. user profile
-    >>> r = linkedin.get('https://api.linkedin.com/v2/me')
-    >>> print(r.content)
+    >>> r = linkedin.get('https://api.linkedin.com/v1/people/~')
+    >>> print r.content

--- a/docs/examples/linkedin.rst
+++ b/docs/examples/linkedin.rst
@@ -13,9 +13,15 @@ command line interactive example below.
     >>> client_id = '<the id you get from linkedin>'
     >>> client_secret = '<the secret you get from linkedin>'
 
+    >>> # LinkedIn OAuth2 requests require scope and redirect_url parameters.
+    >>> # Ensure these values match the auth values in your LinkedIn App 
+    >>> # (see auth tab on LinkedIn Developer page)
+    >>> scope = ['r_liteprofile']
+    >>> redirect_url = 'http://127.0.0.1'
+    
     >>> # OAuth endpoints given in the LinkedIn API documentation
-    >>> authorization_base_url = 'https://www.linkedin.com/uas/oauth2/authorization'
-    >>> token_url = 'https://www.linkedin.com/uas/oauth2/accessToken'
+    >>> authorization_base_url = 'https://www.linkedin.com/oauth/v2/authorization'
+    >>> token_url = 'https://www.linkedin.com/oauth/v2/accessToken'
 
     >>> from requests_oauthlib import OAuth2Session
     >>> from requests_oauthlib.compliance_fixes import linkedin_compliance_fix
@@ -25,15 +31,16 @@ command line interactive example below.
 
     >>> # Redirect user to LinkedIn for authorization
     >>> authorization_url, state = linkedin.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print(f'Please go here and authorize: {authorization_url}')
 
     >>> # Get the authorization verifier code from the callback url
-    >>> redirect_response = raw_input('Paste the full redirect URL here:')
+    >>> redirect_response = input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
     >>> linkedin.fetch_token(token_url, client_secret=client_secret,
+    ...                      include_client_id=True,
     ...                      authorization_response=redirect_response)
 
     >>> # Fetch a protected resource, i.e. user profile
-    >>> r = linkedin.get('https://api.linkedin.com/v1/people/~')
-    >>> print r.content
+    >>> r = linkedin.get('https://api.linkedin.com/v2/me')
+    >>> print(r.content)

--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .facebook import facebook_compliance_fix
 from .fitbit import fitbit_compliance_fix
+from .linkedin import linkedin_compliance_fix
 from .slack import slack_compliance_fix
 from .instagram import instagram_compliance_fix
 from .mailchimp import mailchimp_compliance_fix

--- a/requests_oauthlib/compliance_fixes/linkedin.py
+++ b/requests_oauthlib/compliance_fixes/linkedin.py
@@ -1,0 +1,21 @@
+from json import loads, dumps
+
+from oauthlib.common import add_params_to_uri, to_unicode
+
+
+def linkedin_compliance_fix(session):
+    def _missing_token_type(r):
+        token = loads(r.text)
+        token["token_type"] = "Bearer"
+        r._content = to_unicode(dumps(token)).encode("UTF-8")
+        return r
+
+    def _non_compliant_param_name(url, headers, data):
+        token = [("oauth2_access_token", session.access_token)]
+        url = add_params_to_uri(url, token)
+        return url, headers, data
+
+    session._client.default_token_placement = "query"
+    session.register_compliance_hook("access_token_response", _missing_token_type)
+    session.register_compliance_hook("protected_request", _non_compliant_param_name)
+    return session

--- a/requests_oauthlib/compliance_fixes/linkedin.py
+++ b/requests_oauthlib/compliance_fixes/linkedin.py
@@ -2,7 +2,10 @@ from json import loads, dumps
 
 from oauthlib.common import add_params_to_uri, to_unicode
 
+from deprecated import deprecated
 
+
+@deprecated("This compliance hook will be removed in version 1.4")
 def linkedin_compliance_fix(session):
     def _missing_token_type(r):
         token = loads(r.text)

--- a/requirements-test-27.txt
+++ b/requirements-test-27.txt
@@ -3,3 +3,4 @@ mock==3.0.5
 requests-mock==1.9.3
 requests==2.26.0
 oauthlib[signedtoken]==3.1.0
+Python-Deprecated==1.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@
 coveralls==3.2.0
 mock==4.0.3
 requests-mock==1.9.3
+Python-Deprecated==1.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 requests>=2.0.0
 oauthlib[signedtoken]>=3.0.0
+Python-Deprecated==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.26.0
 oauthlib[signedtoken]==3.1.1
+Python-Deprecated==1.1.0

--- a/tests/test_compliance_fixes.py
+++ b/tests/test_compliance_fixes.py
@@ -14,6 +14,7 @@ from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from requests_oauthlib import OAuth2Session
 from requests_oauthlib.compliance_fixes import facebook_compliance_fix
 from requests_oauthlib.compliance_fixes import fitbit_compliance_fix
+from requests_oauthlib.compliance_fixes import linkedin_compliance_fix
 from requests_oauthlib.compliance_fixes import mailchimp_compliance_fix
 from requests_oauthlib.compliance_fixes import weibo_compliance_fix
 from requests_oauthlib.compliance_fixes import slack_compliance_fix
@@ -97,6 +98,43 @@ class FitbitComplianceFixTest(TestCase):
 
         self.assertEqual(token["access_token"], "access")
         self.assertEqual(token["refresh_token"], "refresh")
+
+
+class LinkedInComplianceFixTest(TestCase):
+    def setUp(self):
+        mocker = requests_mock.Mocker()
+        mocker.post(
+            "https://www.linkedin.com/uas/oauth2/accessToken",
+            json={"access_token": "linkedin"},
+        )
+        mocker.post(
+            "https://api.linkedin.com/v1/people/~/shares",
+            status_code=201,
+            json={
+                "updateKey": "UPDATE-3346389-595113200",
+                "updateUrl": "https://www.linkedin.com/updates?discuss=abc&scope=xyz",
+            },
+        )
+        mocker.start()
+        self.addCleanup(mocker.stop)
+
+        linkedin = OAuth2Session("someclientid", redirect_uri="https://i.b")
+        self.session = linkedin_compliance_fix(linkedin)
+
+    def test_fetch_access_token(self):
+        token = self.session.fetch_token(
+            "https://www.linkedin.com/uas/oauth2/accessToken",
+            client_secret="someclientsecret",
+            authorization_response="https://i.b/?code=hello",
+        )
+        self.assertEqual(token, {"access_token": "linkedin", "token_type": "Bearer"})
+
+    def test_protected_request(self):
+        self.session.token = {"access_token": "dummy-access-token"}
+        response = self.session.post("https://api.linkedin.com/v1/people/~/shares")
+        url = response.request.url
+        query = parse_qs(urlparse(url).query)
+        self.assertEqual(query["oauth2_access_token"], ["dummy-access-token"])
 
 
 class MailChimpComplianceFixTest(TestCase):


### PR DESCRIPTION
Semantic version mistake was made when releasing 1.3.1, the Linkedin compliance fix which was removed from the code base, api breaking change, did not trigger a main version release increment. e.g. 1.4 instead of 1.3.1.

This PR reverts the Linkedin compliance hook removal, and instead adds a deprecation warning. Can remove next major version release. Return Linkedin example file to original state as well as bringing back unit tests.

Updates HISTORY and AUTHOR file.