### PR TITLE
fix: issue 411

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -529,14 +529,14 @@ class OAuth2Session(requests.Session):
                     token = self.refresh_token(
                         self.auto_refresh_url, auth=auth, **kwargs
                     )
+                    url, headers, data = self._client.add_token(
+                        url, http_method=method, body=data, headers=headers
+                    )
                     if self.token_updater:
                         log.debug(
                             "Updating token to %s using %s.", token, self.token_updater
                         )
                         self.token_updater(token)
-                        url, headers, data = self._client.add_token(
-                            url, http_method=method, body=data, headers=headers
-                        )
                     else:
                         raise TokenUpdated(token)
                 else:


### PR DESCRIPTION
It appears that if a `token_updater` is not specified, the client will not get updated. Instead of providing a default `token_updater`, we can instead move this client update call to happen after refresh regardless