### PR TITLE
Give description to tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=py27,py34,py35,py36,py37,py38,py39,py310,pypy,pypy3,docs,readme,black
 
 [testenv]
+description=run test on {basepython}
 deps=
     -r{toxinidir}/requirements-test.txt
 commands=coverage run --source=requests_oauthlib -m unittest discover
@@ -18,6 +19,7 @@ deps=
 # tox -e docs to mimick readthedocs build.
 # should be similar to .readthedocs.yaml pipeline
 [testenv:docs]
+description=mimic readthedocs build
 basepython=python3.7
 skipsdist=True
 deps=
@@ -28,12 +30,14 @@ commands=make clean html
 
 # tox -e readme to mimick pypi validation of readme/rst files.
 [testenv:readme]
+description=mimic pypi validation of readme/rst files
 basepython=python3.7
 deps=twine>=1.12.0
 commands=
         twine check .tox/dist/*
 
 [testenv:black]
+description=show diff of code format
 basepython=python3.7
 deps=black
 commands=black --check --diff .


### PR DESCRIPTION
```
$ tox -av
...
default environments:
py27   -> run test on python2.7
py34   -> run test on python3.4
py35   -> run test on python3.5
py36   -> run test on python3.6
py37   -> run test on python3.7
py38   -> run test on python3.8
py39   -> run test on python3.9
py310  -> run test on python3.10
pypy   -> run test on pypy
pypy3  -> run test on pypy3
docs   -> mimic readthedocs build
readme -> mimic pypi validation of readme/rst files
black  -> show diff of code format
```