### PR TITLE
README.rst: Update the URL for requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Requests-OAuthlib |build-status| |coverage-status| |docs|
 =========================================================
 
-This project provides first-class OAuth library support for `Requests <http://python-requests.org>`_.
+This project provides first-class OAuth library support for `Requests <https://requests.readthedocs.io>`_.
 
 The OAuth 1 workflow
 --------------------


### PR DESCRIPTION
The old destination is no longer working.

http://python-requests.org --> https://requests.readthedocs.io