### PR TITLE
GitHub Actions: Add Python 3.11 to the testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,22 +13,24 @@ jobs:
         include:
           - python-version: "2.7"
             tox-env: py27
-          - python-version: "3.6"
-            tox-env: py36
+          # - python-version: "3.6"  # GitHub Actions ubuntu-latest no longer has Py36
+          #  tox-env: py36
           - python-version: "3.7"
-            tox-env: py37,docs,readme,black
+            tox-env: py37,black  # ,docs,readme
           - python-version: "3.8"
             tox-env: py38
           - python-version: "3.9"
             tox-env: py39
           - python-version: "3.10"
             tox-env: py310
-          - python-version: "pypy3"
-            tox-env: pypy3
+          - python-version: "3.11"
+            tox-env: py311
+          # - python-version: "pypy3.9"  # Not working with new Rust-based cryptography
+          #  tox-env: pypy3
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies

--- a/requests_oauthlib/oauth1_auth.py
+++ b/requests_oauthlib/oauth1_auth.py
@@ -18,6 +18,7 @@ if is_py3:
 
 log = logging.getLogger(__name__)
 
+
 # OBS!: Correct signing of requests are conditional on invoking OAuth1
 # as the last step of preparing a request, or at least having the
 # content-type set properly.
@@ -42,7 +43,6 @@ class OAuth1(AuthBase):
         force_include_body=False,
         **kwargs
     ):
-
         try:
             signature_type = signature_type.upper()
         except AttributeError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,py38,py39,py310,pypy,pypy3,docs,readme,black
+envlist=py27,py34,py35,py36,py37,py38,py39,py310,py311,pypy,pypy3,docs,readme,black
 
 [testenv]
 description=run test on {basepython}
@@ -25,7 +25,7 @@ skipsdist=True
 deps=
     -r{toxinidir}/docs/requirements.txt
 changedir=docs
-whitelist_externals=make
+allowlist_externals=make
 commands=make clean html
 
 # tox -e readme to mimic pypi validation of readme/rst files.


### PR DESCRIPTION
GitHub Actions: pypy3 --> pypy3.9

psf/black formatting for 2023 stable format

tox.ini: whitelist_externals --> allowlist_externals

GitHub Actions ubuntu-latest no longer has Py36

pypy3.9 is not working with new Rust-based cryptography