### PR TITLE
Removed older python versions (2.7,<=3.7)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,9 +25,9 @@ jobs:
             tox-env: pypy310
     steps:
     - name: Install pypy cryptography dependencies
-      if: ${{ matrix.python-version }} == "pypy3.10"
+      if: startsWith(matrix.python-version, 'pypy')
       run: |
-        sudo apt update && apt install -y build-essential cargo rustc pkg-config libffi-dev libssl-dev pypy3-dev
+        sudo apt update && sudo apt install -y build-essential cargo rustc pkg-config libffi-dev libssl-dev pypy3-dev
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,10 +24,6 @@ jobs:
           - python-version: "pypy3.10"
             tox-env: pypy310
     steps:
-    - name: Install pypy cryptography dependencies
-      if: startsWith(matrix.python-version, 'pypy')
-      run: |
-        sudo apt update && sudo apt install -y build-essential cargo rustc pkg-config libffi-dev libssl-dev pypy3-dev
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,18 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "2.7"
-            tox-env: py27
-          - python-version: "3.6"
-            tox-env: py36
-          - python-version: "3.7"
-            tox-env: py37,docs,readme,black
           - python-version: "3.8"
             tox-env: py38
           - python-version: "3.9"
             tox-env: py39
           - python-version: "3.10"
-            tox-env: py310
+            tox-env: py310,docs,readme,ruff
           - python-version: "3.11"
             tox-env: py311
           - python-version: "3.12"
@@ -41,7 +35,6 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install tox
     - name: Install coveralls dependencies
-      if: ${{ matrix.python-version != '2.7' }}
       run: |
         python -m pip install coveralls coverage-lcov toml
     - name: Execute tests with tox
@@ -50,12 +43,10 @@ jobs:
       run: |
         tox
     - name: Coverage format into lcov
-      if: ${{ matrix.python-version != '2.7' }}
       run: |
         coverage-lcov --output_file_path lcov.info
     - name: Coveralls Parallel
       uses: coverallsapp/github-action@1.1.3
-      if: ${{ matrix.python-version != '2.7' }}
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ matrix.python-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,12 @@ jobs:
             tox-env: py311
           - python-version: "3.12"
             tox-env: py312
-          - python-version: "pypy3"
-            tox-env: pypy3
+          - python-version: "pypy3.10"
+            tox-env: pypy310
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@1.1.3
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: lcov.info

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,10 @@ jobs:
           - python-version: "pypy3.10"
             tox-env: pypy310
     steps:
+    - name: Install pypy cryptography dependencies
+      if: ${{ matrix.python-version }} == "pypy3.10"
+      run: |
+        sudo apt update && apt install -y build-essential cargo rustc pkg-config libffi-dev libssl-dev pypy3-dev
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,13 +1,12 @@
-Requests-oauthlib is written and maintained by Kenneth Reitz and various
-contributors:
+Requests-oauthlib has been written by Kenneth Reitz, various contributors:
 
-Development Lead
+Initial Write-up
 ----------------
 
 - Kenneth Reitz <me@kennethreitz.com>
 
-Patches and Suggestions
------------------------
+Maintainers & Contributors
+--------------------------
 
 - Cory Benfield <cory@lukasa.co.uk>
 - Ib Lundgren <ib.lundgren@gmail.com>
@@ -15,6 +14,7 @@ Patches and Suggestions
 - Imad Mouhtassem <mouhtasi@gmail.com>
 - Johan Euphrosine <proppy@google.com>
 - Johannes Spielmann <js@shezi.de>
+- Jonathan Huot <jonathan.huot@gmail.com>
 - Martin Trigaux <me@mart-e.be>
 - Matt McClure <matt.mcclure@mapmyfitness.com>
 - Mikhail Sobolev <mss@mawhrin.net>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,9 @@ v1.4.0 (TBD)
 - ``OAuth2Session`` constructor now uses its ``client.scope`` when a ``client``
   is provided and ``scope`` is not overridden. Fixes `#408
   <https://github.com/requests/requests-oauthlib/issues/408>`_
-- Add support for Python 3.8-3.10
+- Add support for Python 3.8-3.12
+- Remove support of Python 2.x, <3.7
+- Migrated to Github Action
 
 
 v1.3.1 (21 January 2022)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,13 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
-from requests_oauthlib import __version__
+from requests_oauthlib import __version__ # noqa: E402
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,11 +7,11 @@ Test simple changes
 
 Requests-OAuthlib is using `tox`_ as main test tool.
 It helps creating the required virtualenv for your python version.
-For example, if you have installed Python3.7:
+For example, if you have installed Python3.8:
 
 .. sourcecode:: bash
 
-   $ tox -e py37
+   $ tox -e py38
 
 
 Validate documentation changes
@@ -40,13 +40,8 @@ In order to run successfully, you will need all versions of Python installed. We
 
 .. sourcecode:: bash
 
-   $ pyenv install 2.7.18
-   $ pyenv install 3.4.10
-   $ pyenv install 3.5.10
-   $ pyenv install 3.6.14
-   $ pyenv install 3.7.11
-   $ pyenv install pypy2.7-7.1.1
-   $ pyenv install pypy3.6-7.1.1
+   $ pyenv install 3.8.18
+   $ pyenv install pypy3.10-7.3.13
 
 
 Publishing a release (for maintainer role)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -42,7 +42,21 @@ In order to run successfully, you will need all versions of Python installed. We
 
    $ pyenv install 3.8.18
    $ pyenv install pypy3.10-7.3.13
+   $ pyenv global pypy3.10-7.3.13  # switch to pypy
 
+
+Build and test via pipeline
+===========================
+
+If you don't want to install multiple python versions, or if you have
+made changes in the pipeline code, it is possible to execute the Github Action
+locally with the `act` tools available here: https://nektosact.com/usage/index.html
+
+Run tests for `pypy3.9`:
+
+```shell
+act -W .github/workflows/run-tests.yml -j tests --matrix python-version:pypy3.9
+```
 
 Publishing a release (for maintainer role)
 ==========================================

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -50,7 +50,7 @@ Publishing a release (for maintainer role)
 Maintainer tasks should always be kept to minimum. Once a release is ready, the suggested approach can be followed:
 
 #. Create new branch release-X.Y.Z
-#. Update the HISTORY.rst file
+#. Update HISTORY.rst and AUTHORS.rst if required
 #. Update the `request_oauthlib/__init__.py`
 #. Raise a pull request to give a chance for all contributors to comment before publishing
 #. Create a TAG vX.Y.Z. By doing this, the pipeline will automatically trigger `twine` and will publish the release to PyPi.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-sphinx<2
-docutils<=0.15  # docutils 0.16 has an error when generating in api.rst
-sphinx_rtd_theme<0.5
+sphinx
+sphinx_rtd_theme
 readthedocs-sphinx-ext

--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -6,7 +6,7 @@ from .oauth1_session import OAuth1Session
 from .oauth2_auth import OAuth2
 from .oauth2_session import OAuth2Session, TokenUpdated
 
-__version__ = "1.3.1"
+__version__ = "1.4.0-dev"
 
 import requests
 

--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 import logging
 
 from .oauth1_auth import OAuth1

--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 from __future__ import absolute_import
 
 from .facebook import facebook_compliance_fix

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -476,7 +476,7 @@ class OAuth2Session(requests.Session):
             r = hook(r)
 
         self.token = self._client.parse_request_body_response(r.text, scope=self.scope)
-        if not "refresh_token" in self.token:
+        if "refresh_token" not in self.token:
             log.debug("No new refresh token given. Re-using old.")
             self.token["refresh_token"] = refresh_token
         return self.token

--- a/requirements-test-27.txt
+++ b/requirements-test-27.txt
@@ -1,5 +1,0 @@
-coveralls==1.11.1
-mock==3.0.5
-requests-mock==1.9.3
-requests==2.26.0
-oauthlib[signedtoken]==3.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-coveralls==3.2.0
+coveralls==3.3.1
 mock==4.0.3
-requests-mock==1.9.3
+requests-mock==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.26.0
-oauthlib[signedtoken]==3.1.1
+requests==2.31.0
+oauthlib[signedtoken]==3.2.2

--- a/tests/test_oauth1_session.py
+++ b/tests/test_oauth1_session.py
@@ -26,7 +26,7 @@ except ImportError:
 if sys.version[0] == "3":
     unicode_type = str
 else:
-    unicode_type = unicode
+    unicode_type = unicode # noqa
 
 
 TEST_RSA_KEY = (
@@ -308,12 +308,6 @@ class OAuth1SessionTest(unittest.TestCase):
 
         generate_nonce.return_value = "abc"
         generate_timestamp.return_value = "123"
-        signature = (
-            "OAuth "
-            'oauth_nonce="abc", oauth_timestamp="123", oauth_version="1.0", '
-            'oauth_signature_method="RSA-SHA1", oauth_consumer_key="foo", '
-            'oauth_verifier="bar", oauth_signature="{sig}"'
-        ).format(sig=TEST_RSA_OAUTH_SIGNATURE)
         sess = OAuth1Session(
             "key",
             "secret",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{38,39,310,311,312,py3},docs,readme,ruff
+envlist=py{38,39,310,311,312,py310},docs,readme,ruff
 
 [testenv]
 description=run test on {basepython}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34,35,36,37,38,39,310,311,312,py,py3},docs,readme,black
+envlist=py{38,39,310,311,312,py3},docs,readme,black
 
 [testenv]
 description=run test on {basepython}
@@ -7,37 +7,28 @@ deps=
     -r{toxinidir}/requirements-test.txt
 commands=coverage run --source=requests_oauthlib -m unittest discover
 
-# special py27 requirements as upstream libraries stopped
-# supporting latest versions
-[testenv:py27]
-deps=
-    -r{toxinidir}/requirements-test-27.txt
-[testenv:pypy]
-deps=
-    -r{toxinidir}/requirements-test-27.txt
-
 # tox -e docs to mimic readthedocs build.
 # should be similar to .readthedocs.yaml pipeline
 [testenv:docs]
 description=mimic readthedocs build
-basepython=python3.7
+basepython=python3.11
 skipsdist=True
 deps=
     -r{toxinidir}/docs/requirements.txt
 changedir=docs
-whitelist_externals=make
+allowlist_externals=make
 commands=make clean html
 
 # tox -e readme to mimic pypi validation of readme/rst files.
 [testenv:readme]
 description=mimic pypi validation of readme/rst files
-basepython=python3.7
+basepython=python3.11
 deps=twine>=1.12.0
 commands=
         twine check .tox/dist/*
 
 [testenv:black]
 description=show diff of code format
-basepython=python3.7
+basepython=python3.11
 deps=black
 commands=black --check --diff .

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,7 @@ commands=make clean html
 description=mimic pypi validation of readme/rst files
 basepython=python3.11
 deps=twine>=1.12.0
-commands=
-        twine check .tox/dist/*
+commands=twine check .tox/.pkg/dist/*
 
 [testenv:ruff]
 basepython=python3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{38,39,310,311,312,py3},docs,readme,black
+envlist=py{38,39,310,311,312,py3},docs,readme,ruff
 
 [testenv]
 description=run test on {basepython}
@@ -27,8 +27,7 @@ deps=twine>=1.12.0
 commands=
         twine check .tox/dist/*
 
-[testenv:black]
-description=show diff of code format
+[testenv:ruff]
 basepython=python3.11
-deps=black
-commands=black --check --diff .
+deps=ruff
+commands=ruff .


### PR DESCRIPTION
This should be the first step to 1.4.0 release, and a refresh of python versions. The codebase hasn't been cleaned, but it can come at a later point in time, or gradually depending the files changes.

The more important is to keep the latest tools (tox, cicd) up to date to allow MR to be included and release more often.