### PR TITLE
Update Python 2 examples in docs to Python 3

### DIFF
--- a/docs/examples/bitbucket.rst
+++ b/docs/examples/bitbucket.rst
@@ -27,10 +27,10 @@ try out the command line interactive example below.
 
     >>> # 3. Redirect user to Bitbucket for authorization
     >>> authorization_url = bitbucket.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print('Please go here and authorize,', authorization_url)
 
     >>> # 4. Get the authorization verifier code from the callback url
-    >>> redirect_response = raw_input('Paste the full redirect URL here:')
+    >>> redirect_response = input('Paste the full redirect URL here:')
     >>> bitbucket.parse_authorization_response(redirect_response)
 
     >>> # 5. Fetch the access token
@@ -38,4 +38,4 @@ try out the command line interactive example below.
 
     >>> # 6. Fetch a protected resource, i.e. user profile
     >>> r = bitbucket.get('https://bitbucket.org/api/1.0/user')
-    >>> print r.content
+    >>> print(r.content)

--- a/docs/examples/facebook.rst
+++ b/docs/examples/facebook.rst
@@ -25,10 +25,10 @@ a callback URL then you can try out the command line interactive example below.
 
     >>> # Redirect user to Facebook for authorization
     >>> authorization_url, state = facebook.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print('Please go here and authorize,', authorization_url)
 
     >>> # Get the authorization verifier code from the callback url
-    >>> redirect_response = raw_input('Paste the full redirect URL here:')
+    >>> redirect_response = input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
     >>> facebook.fetch_token(token_url, client_secret=client_secret,
@@ -36,4 +36,4 @@ a callback URL then you can try out the command line interactive example below.
 
     >>> # Fetch a protected resource, i.e. user profile
     >>> r = facebook.get('https://graph.facebook.com/me?')
-    >>> print r.content
+    >>> print(r.content)

--- a/docs/examples/github.rst
+++ b/docs/examples/github.rst
@@ -22,10 +22,10 @@ command line interactive example below.
 
     >>> # Redirect user to GitHub for authorization
     >>> authorization_url, state = github.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print('Please go here and authorize,', authorization_url)
 
     >>> # Get the authorization verifier code from the callback url
-    >>> redirect_response = raw_input('Paste the full redirect URL here:')
+    >>> redirect_response = input('Paste the full redirect URL here:')
 
     >>> # Fetch the access token
     >>> github.fetch_token(token_url, client_secret=client_secret,
@@ -33,4 +33,4 @@ command line interactive example below.
 
     >>> # Fetch a protected resource, i.e. user profile
     >>> r = github.get('https://api.github.com/user')
-    >>> print r.content
+    >>> print(r.content)

--- a/docs/examples/tumblr.rst
+++ b/docs/examples/tumblr.rst
@@ -24,14 +24,14 @@ Enter a call back url (can just be http://www.tumblr.com/dashboard) and get the 
 
     >>> # Link user to authorization page
     >>> authorization_url = tumblr.authorization_url(authorization_base_url)
-    >>> print 'Please go here and authorize,', authorization_url
+    >>> print('Please go here and authorize,', authorization_url)
 
     >>> # Get the verifier code from the URL
-    >>> redirect_response = raw_input('Paste the full redirect URL here: ')
+    >>> redirect_response = input('Paste the full redirect URL here: ')
     >>> tumblr.parse_authorization_response(redirect_response)
 
     >>> # Fetch the access token
     >>> tumblr.fetch_access_token(access_token_url)
 
     >>> # Fetch a protected resource
-    >>> print tumblr.get('http://api.tumblr.com/v2/user/dashboard')
+    >>> print(tumblr.get('http://api.tumblr.com/v2/user/dashboard'))

--- a/docs/oauth1_workflow.rst
+++ b/docs/oauth1_workflow.rst
@@ -71,8 +71,8 @@ Workflow example showing use of both OAuth1 and OAuth1Session
 
     >>> # Using OAuth1Session
     >>> authorization_url = oauth.authorization_url(base_authorization_url)
-    >>> print 'Please go here and authorize,', authorization_url
-    >>> redirect_response = raw_input('Paste the full redirect URL here: ')
+    >>> print('Please go here and authorize,', authorization_url)
+    >>> redirect_response = input('Paste the full redirect URL here: ')
     >>> oauth_response = oauth.parse_authorization_response(redirect_response)
     {
         "oauth_token": "Z6eEdO8MOmk394WozF5oKyuAv855l4Mlqo7hhlSLik",
@@ -83,8 +83,8 @@ Workflow example showing use of both OAuth1 and OAuth1Session
     >>> # Using OAuth1 auth helper
     >>> authorize_url = base_authorization_url + '?oauth_token='
     >>> authorize_url = authorize_url + resource_owner_key
-    >>> print 'Please go here and authorize,', authorize_url
-    >>> verifier = raw_input('Please input the verifier')
+    >>> print('Please go here and authorize,', authorize_url)
+    >>> verifier = input('Please input the verifier')
 
 3. Obtain an access token from the OAuth provider. Save this token as it can be
    re-used later. In this step we will re-use most of the credentials obtained
@@ -153,12 +153,12 @@ OAuth takes many forms, so let's take a look at a few different forms:
     import requests
     from requests_oauthlib import OAuth1
 
-    url = u'https://api.twitter.com/1/account/settings.json'
+    url = 'https://api.twitter.com/1/account/settings.json'
 
-    client_key = u'...'
-    client_secret = u'...'
-    resource_owner_key = u'...'
-    resource_owner_secret = u'...'
+    client_key = '...'
+    client_secret = '...'
+    resource_owner_key = '...'
+    resource_owner_secret = '...'
 
 
 Header signing (recommended):

--- a/docs/oauth2_workflow.rst
+++ b/docs/oauth2_workflow.rst
@@ -72,8 +72,8 @@ the provider is Google and the protected resource is the user's profile.
             # parameters.
             access_type="offline", prompt="select_account")
 
-    >>> print 'Please go to %s and authorize access.' % authorization_url
-    >>> authorization_response = raw_input('Enter the full callback URL')
+    >>> print(f'Please go to {authorization_url} and authorize access.')
+    >>> authorization_response = input('Enter the full callback URL')
 
 2. Fetch an access token from the provider using the authorization code
    obtained during user authorization.

--- a/requests_oauthlib/oauth1_session.py
+++ b/requests_oauthlib/oauth1_session.py
@@ -85,7 +85,7 @@ class OAuth1Session(requests.Session):
     'https://api.twitter.com/oauth/authorize?oauth_token=sdf0o9823sjdfsdf&oauth_callback=https%3A%2F%2F127.0.0.1%2Fcallback'
     >>>
     >>> # Third step. Fetch the access token
-    >>> redirect_response = raw_input('Paste the full redirect URL here.')
+    >>> redirect_response = input('Paste the full redirect URL here.')
     >>> oauth_session.parse_authorization_response(redirect_response)
     {
         'oauth_token: 'kjerht2309u',


### PR DESCRIPTION
I recently came across this library and saw that it still had Python 2 references in the docs. I saw #523 was open, so I went ahead and updated the documentation to use Python 3 examples.

Once #523 is merged this could be merged as well.

---

*(Out of scope, but leaving this here for now, could make this a separate issue)*

Now that we're dropping Python <=3.7 there are a lot of Python 3 related changes and quality of life improvements we can now make:
* Add type annotations
* Remove remaining Python 2 compatibility checks
* Improve testing infrastructure

I wouldn't mind working on these in my free time if we decide these would be useful!