### PR TITLE
Adds logger filter for TOKENS when logging in DEBUG MODE

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Maintainers & Contributors
 - Craig Anderson <craiga@craiga.id.au>
 - Hugo van Kemenade <https://github.com/hugovk>
 - Jacques Troussard <https://github.com/jtroussard>
+- Erland Vollset <https://github.com/erlendvollset>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ Maintainers & Contributors
 - Sylvain Marie <sylvain.marie@se.com>
 - Craig Anderson <craiga@craiga.id.au>
 - Hugo van Kemenade <https://github.com/hugovk>
+- Jacques Troussard <https://github.com/jtroussard>

--- a/README.rst
+++ b/README.rst
@@ -56,3 +56,22 @@ To install requests and requests_oauthlib you can use pip:
    :alt: Documentation Status
    :scale: 100%
    :target: https://requests-oauthlib.readthedocs.io/
+
+Advanced Configurations
+-----------------------
+
+### Logger Configuration Framework
+
+`requests-oauthlib` now includes a flexible framework for applying custom filters and configurations to the logger, enhancing control over logging behavior and improving security.
+
+#### Custom Filters
+
+- **Debug Mode Token Filter**: To enhance security and provide more control over logging of sensitive information, requests-oauthlib introduces the Debug Mode Token Filter. This feature is controlled via the DEBUG_MODE_TOKEN_FILTER environment variable, allowing the suppression or masking of sensitive data in logs.
+
+  ##### Configuring the Debug Mode Token Filter
+
+  - **Environment Variable**: `DEBUG_MODE_TOKEN_FILTER`
+  - **Options**:
+    - `DEFAULT`: No alteration to logging behavior.
+    - `MASK`: Masks sensitive tokens in logs.
+    - `SUPPRESS`: Prevents logging of potentially sensitive information. (logger ignores these logs entirely)

--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -6,6 +6,8 @@ from .oauth1_session import OAuth1Session
 from .oauth2_auth import OAuth2
 from .oauth2_session import OAuth2Session, TokenUpdated
 
+from .log_filters import DebugModeTokenFilter
+
 __version__ = "2.0.0"
 
 import requests
@@ -18,3 +20,4 @@ if requests.__version__ < "2.0.0":
     raise Warning(msg % requests.__version__)
 
 logging.getLogger("requests_oauthlib").addHandler(logging.NullHandler())
+logging.getLogger("requests_oauthlib").addFilter(DebugModeTokenFilter())

--- a/requests_oauthlib/log_filters.py
+++ b/requests_oauthlib/log_filters.py
@@ -1,0 +1,23 @@
+import os
+import re
+import logging
+
+class DebugModeTokenFilter(logging.Filter): # <-- inherent from the Filter class
+    def __init__(self):
+        super().__init__()
+        # set the behavior/configuration of the filter by the environment variable 
+        self.mode = os.getenv('DEBUG_MODE_TOKEN_FILTER', 'DEFAULT').upper() 
+
+    def filter(self, record):
+        if self.mode == "MASK":
+            # While this doesn't directly target the headers as @erlendvollset 's post originally targets
+            # this wider approach of targeting the "Bearer" key word I believe provides complete coverage.
+            # However I would still recommend some more research to see if this regex would need to be improved
+            # to provide a secure/trusted solution.
+            record.msg = re.sub(r'Bearer (\w+)', '[MASKED]', record.getMessage())
+        elif self.mode == "SUPPRESS":
+            return False
+        elif self.mode == "DEFAULT":
+            msg = "Your logger, when in DEBUG mode, will log TOKENS"
+            raise Warning(msg)
+        return True

--- a/tests/test_log_filters.py
+++ b/tests/test_log_filters.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+from logging import LogRecord
+from requests_oauthlib.log_filters import DebugModeTokenFilter
+
+class TestDebugModeTokenFilter(unittest.TestCase):
+
+    def setUp(self):
+        self.record = LogRecord(name="test", level=20, pathname=None, lineno=None, msg="Bearer i-am-a-token", args=None, exc_info=None)
+
+    @patch.dict('os.environ', {'DEBUG_MODE_TOKEN_FILTER': 'MASK'})
+    def test_mask_mode(self):
+        filter = DebugModeTokenFilter()
+        filter.filter(self.record)
+        self.assertIn('[MASKED]', self.record.msg)
+
+    @patch.dict('os.environ', {'DEBUG_MODE_TOKEN_FILTER': 'SUPPRESS'})
+    def test_suppress_mode(self):
+        filter = DebugModeTokenFilter()
+        result = filter.filter(self.record)
+        self.assertFalse(result) # Check that nothing is logged
+
+    @patch.dict('os.environ', {'DEBUG_MODE_TOKEN_FILTER': 'DEFAULT'})
+    def test_default_mode(self):
+        filter = DebugModeTokenFilter()
+        with self.assertRaises(Warning) as context:
+            filter.filter(self.record)
+        self.assertTrue("Your logger, when in DEBUG mode, will log TOKENS" in str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is a derivative of another #532  

This PR addresses the same issue but aims to demonstrate a broader perspective on implementation. While the original PR highlighted a significant concern, the proposed solution here follows an existing patten of configuring the logger and leveraging the features within the logger itself. Following this pattern reinforces and encourages contributions in a more uniform and predictable way for future logger configurations. 

This approach also enables a more comprehensive cleansing of sensitive information from logs, extending beyond headers to all areas of the code base. 

The necessity to create a new PR stems from the considerable deviation in approach, which couldn't be effectively communicated within the framework of #532's PR discussion. To acknowledge the foundational work laid by the original proposal, this submission incorporates co-authoring commits, reinforcing a collaborative effort towards a scalable and secure logging strategy.