### PR TITLE
Support non-x-www-form-urlencoded bodies returned from refresh_token_request compliance hook

### DIFF
--- a/requests_oauthlib/compliance_fixes/__init__.py
+++ b/requests_oauthlib/compliance_fixes/__init__.py
@@ -7,3 +7,4 @@ from .mailchimp import mailchimp_compliance_fix
 from .weibo import weibo_compliance_fix
 from .plentymarkets import plentymarkets_compliance_fix
 from .ebay import ebay_compliance_fix
+from .wix import wix_compliance_fix

--- a/requests_oauthlib/compliance_fixes/wix.py
+++ b/requests_oauthlib/compliance_fixes/wix.py
@@ -1,0 +1,36 @@
+import json
+from oauthlib.common import urldecode
+
+"""
+Wix requires the request body for token requests to be sent in JSON format
+instead of x-www-form-urlencoded.
+"""
+def wix_compliance_fix(session):
+
+    def _non_compliant_access_token_request_body(
+            url: str, headers: dict, request_kwargs: dict
+    ):
+        """
+        Move the request body from the `data` kwarg to the `json` kwarg,
+        and set the `Content-Type` header to `application/json`.
+        """
+        headers["Content-Type"] = "application/json"
+        request_kwargs["json"] = request_kwargs["data"]
+        del request_kwargs["data"]
+        return url, headers, request_kwargs
+
+    def _non_compliant_refresh_token_request_body(
+            token_url: str, headers: dict, body: str
+    ):
+        """
+        Convert the body from a urlencoded string to a JSON string,
+        and set the `Content-Type` header to `application/json`.
+        """
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(dict(urldecode(body)))
+        return token_url, headers, body
+
+    session.register_compliance_hook("access_token_request", _non_compliant_access_token_request_body)
+    session.register_compliance_hook("refresh_token_request", _non_compliant_refresh_token_request_body)
+
+    return session

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -473,9 +473,15 @@ class OAuth2Session(requests.Session):
             log.debug("Invoking refresh_token_request hook %s.", hook)
             token_url, headers, body = hook(token_url, headers, body)
 
+        try:
+            body = dict(urldecode(body))
+        except ValueError:
+            log.debug("Could not decode body as urlencoded data. Using body in request as is: %s", body)
+            pass
+
         r = self.post(
             token_url,
-            data=dict(urldecode(body)),
+            data=body,
             auth=auth,
             timeout=timeout,
             headers=headers,

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -473,11 +473,8 @@ class OAuth2Session(requests.Session):
             log.debug("Invoking refresh_token_request hook %s.", hook)
             token_url, headers, body = hook(token_url, headers, body)
 
-        try:
+        if headers['Content-Type'] == "application/x-www-form-urlencoded":
             body = dict(urldecode(body))
-        except ValueError:
-            log.debug("Could not decode body as urlencoded data. Using body in request as is: %s", body)
-            pass
 
         r = self.post(
             token_url,


### PR DESCRIPTION
Addresses https://github.com/requests/requests-oauthlib/issues/544

Adding similar capabilities to the `refresh_token_request` compliance hook as is possible in the `access_token_request` hook, to allow for non standard, non `x-www-form-urlencoded` request bodies in token refresh requests.

Additionally, adding in a Wix compliance fix showing how to use the `access_token_request` and `refresh_token_request` compliance hooks to successfully request and refresh tokens with Wix. Docs here: https://dev.wix.com/docs/rest/app-management/oauth-2/request-an-access-token 

I added tests for the compliance fix to show the `refresh_token_request` updates work (as well as testing them manually against the Wix API from my own project). I'm happy to add tests in `test_oauth2_session.py` as well, I just wasn't sure exactly what to add, as the code I added should only ever be triggered by compliance hooks changing the request body to something non-standard.

I am also open to a completely different implementation here, this was just the option that I saw would solve my problem and looked to be fully backwards compatible with anyone's existing `refresh_token_request` compliance hooks.