### PR TITLE
Update README.rst - Add a downloads per month badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Requests-OAuthlib |build-status| |coverage-status| |docs|
+Requests-OAuthlib |build-status| |coverage-status| |docs| |downloads|
 =========================================================
 
 This project provides first-class OAuth library support for `Requests <https://requests.readthedocs.io>`_.
@@ -56,3 +56,6 @@ To install requests and requests_oauthlib you can use pip:
    :alt: Documentation Status
    :scale: 100%
    :target: https://requests-oauthlib.readthedocs.io/
+.. |downloads| image:: https://assets.piptrends.com/get-last-month-downloads-badge/requests-oauthlib.svg
+    :alt: requests-oauthlib Downloads Last Month by pip Trends
+    :target: https://piptrends.com/package/requests-oauthlib


### PR DESCRIPTION
Added a badge displaying the monthly download count from pip Trends. You can view more details at - https://piptrends.com/package/requests-oauthlib

(If necessary, the link from the badge to the package's pip Trends page can be removed. We just want to showcase a badge we have created.)
