### PR TITLE
fix: explicitly add scope to OAuth2Session.prepare_request_body

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -354,6 +354,7 @@ class OAuth2Session(requests.Session):
             body=body,
             redirect_uri=self.redirect_uri,
             include_client_id=include_client_id,
+            scope=self._scope,
             **kwargs
         )
 


### PR DESCRIPTION
The `fetch_token` function calls the `prepare_request_body` function. However, it does not pass the scope initialized in the `OAuth2Session` class constructor. This leads to `Missing access token` error in cases where the `scope` is a required parameter. I believe explicitly passing it here makes sense.

This fix may be related to https://github.com/requests/requests-oauthlib/issues/324