### PR TITLE
oauth2_session.py should honour self.verify

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -384,7 +384,7 @@ class OAuth2Session(requests.Session):
             timeout=timeout,
             headers=headers,
             auth=auth,
-            verify=verify,
+            verify=verify if verify is not None else self.verify,
             proxies=proxies,
             cert=cert,
             **request_kwargs
@@ -479,7 +479,7 @@ class OAuth2Session(requests.Session):
             auth=auth,
             timeout=timeout,
             headers=headers,
-            verify=verify,
+            verify=verify if verify is not None else self.verify,
             withhold_token=True,
             proxies=proxies,
         )


### PR DESCRIPTION
* According to the request manual, `verify` can be set for the verification setup
  * refresh_token() & fetch_token() does not honour the settings from requests.Session().verify.
  * That's why this is the patch for using self.verify as the value if the verify from function is not being provided

Note, it may be an incompatible fix.