### PR TITLE
Add Support for Device Code Authorization

### DIFF
--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -5,6 +5,8 @@ from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
 from oauthlib.oauth2 import LegacyApplicationClient
 from oauthlib.oauth2 import TokenExpiredError, is_secure_transport
 import requests
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
+from requests import HTTPError
 
 log = logging.getLogger(__name__)
 
@@ -424,8 +426,9 @@ class OAuth2Session(requests.Session):
         """
         Prompts request for device code token at `token_endpoint`. Used by
         DeviceCodeClient. Will continuously loop and check the device code
+        until the number of attempts are met or the access token is given.
 
-        :param token_endpoint: endpoint for retrieving the token code
+        :param token_endpoint: Endpoint for retrieving the token code
         :param interval: Time between attempts to check for approval. By default
                          will use the interval returned by the first request.
         :param max_attempts: Number of attempts to check for approval. By
@@ -472,8 +475,7 @@ class OAuth2Session(requests.Session):
         while token is None:
             if max_attempts is not None and attempts >= max_attempts:
                 raise TimeoutError(
-                    "Device code was not authorized within %d attempts."
-                    % max_attempts
+                    f"Device code was not authorized within {max_attempts} attempts."
                 )
             attempts += 1
             time.sleep(interval)

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -427,8 +427,7 @@ class OAuth2Session(requests.Session):
          token_endpoint,
          client_id=None,
          client_secret=None,
-         interval=None,
-         max_poll_attempts=None
+         interval=None
     ):
         """
         Prompts request for device code token at `token_endpoint`. Used by
@@ -444,14 +443,10 @@ class OAuth2Session(requests.Session):
                               requests.
         :param interval: Time in seconds between device code polls. By default
                          will use the interval returned by the first request.
-        :param max_poll_attempts: Number of attempts to check for approval. By
-                            default will be infinite.
         :return: Token dict
         """
-
         if client_id is None:
             client_id = self.client_id
-
         device_code_response = self.request(
             "GET",
             token_endpoint,
@@ -472,10 +467,11 @@ class OAuth2Session(requests.Session):
             raise e
 
         device_data = device_code_response.json()
-
         device_code = device_data["device_code"]
         user_code = device_data["user_code"]
         verification_uri = device_data["verification_uri"]
+        expires_in = device_data["expires_in"]
+        start_time = time.time()
         log.debug("Device code response data: %s", device_data)
         print(f"Go to: {verification_uri}")
         print(f"Enter code: {user_code}")
@@ -486,9 +482,9 @@ class OAuth2Session(requests.Session):
             interval = device_data.get("interval", 5)
         attempts = 0
         while token is None:
-            if max_poll_attempts is not None and attempts >= max_poll_attempts:
+            if time.time() - start_time > expires_in:
                 raise TimeoutError(
-                    f"Device code was not authorized within {max_poll_attempts} attempts."
+                    "Device code expired"
                 )
             attempts += 1
             time.sleep(interval)
@@ -512,7 +508,6 @@ class OAuth2Session(requests.Session):
                     print(f"Polling too fast, trying again in {interval}s")
                 else:
                     raise e
-
         return token
 
     def refresh_token(

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -422,7 +422,14 @@ class OAuth2Session(requests.Session):
         self.token = self._client.token
         return self.token
 
-    async def token_from_device_code(self, token_endpoint, client_id=None, client_secret=None, interval=None, max_attempts=None):
+    async def token_from_device_code(
+         self,
+         token_endpoint,
+         client_id=None,
+         client_secret=None,
+         interval=None,
+         max_poll_attempts=None
+    ):
         """
         Prompts request for device code token at `token_endpoint`. Used by
         DeviceCodeClient. Will continuously loop and check the device code
@@ -431,7 +438,7 @@ class OAuth2Session(requests.Session):
         :param token_endpoint: Endpoint for retrieving the token code
         :param interval: Time between attempts to check for approval. By default
                          will use the interval returned by the first request.
-        :param max_attempts: Number of attempts to check for approval. By
+        :param max_poll_attempts: Number of attempts to check for approval. By
                             default will be infinite.
         :return: Token dict
         """
@@ -473,9 +480,9 @@ class OAuth2Session(requests.Session):
             interval = device_data.get("interval", 5)
         attempts = 0
         while token is None:
-            if max_attempts is not None and attempts >= max_attempts:
+            if max_poll_attempts is not None and attempts >= max_poll_attempts:
                 raise TimeoutError(
-                    f"Device code was not authorized within {max_attempts} attempts."
+                    f"Device code was not authorized within {max_poll_attempts} attempts."
                 )
             attempts += 1
             time.sleep(interval)
@@ -487,20 +494,16 @@ class OAuth2Session(requests.Session):
                     method="GET",
                     device_code=device_code,
                     include_client_id=True,
+                    client_id=client_id,
+                    client_secret=client_secret,
                     scope=self.scope,
-                    data={
-                        "code": device_code,
-                        "device_code": device_code,
-                    }
                 )
             except CustomOAuth2Error as e:
                 if "authorization_pending" in str(e):
                     print(e.description)
-                    continue
                 elif "slow_down" in str(e):
                     interval+=5
                     print(f"Polling too fast, trying again in {interval}s")
-                    continue
                 else:
                     raise e
 

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -432,11 +432,17 @@ class OAuth2Session(requests.Session):
     ):
         """
         Prompts request for device code token at `token_endpoint`. Used by
-        DeviceCodeClient. Will continuously loop and check the device code
-        until the number of attempts are met or the access token is given.
+        DeviceCodeClient. Will continuously loop and poll `token_endpoint` to
+        check if the device code until the number of attempts are met or the
+        access token is given.
 
         :param token_endpoint: Endpoint for retrieving the token code
-        :param interval: Time between attempts to check for approval. By default
+        :param client_id: Client id to be used for token retrieval.  If not
+                          given, the client id of this session is used.
+        :param client_secret: The `client_secret` paired with `client_id`. If
+                              the value is `None`, it will be omitted from the
+                              requests.
+        :param interval: Time in seconds between device code polls. By default
                          will use the interval returned by the first request.
         :param max_poll_attempts: Number of attempts to check for approval. By
                             default will be infinite.

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -469,8 +469,8 @@ class OAuth2Session(requests.Session):
 
         token = None
         if interval is None:
-            # Fallback to 15s if no interval given anywhere
-            interval = device_data.get("interval", 15)
+            # RFC8628 specifies that clients MUST use 5 as the default
+            interval = device_data.get("interval", 5)
         attempts = 0
         while token is None:
             if max_attempts is not None and attempts >= max_attempts:

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -420,6 +420,90 @@ class OAuth2Session(requests.Session):
         self.token = self._client.token
         return self.token
 
+    async def token_from_device_code(self, token_endpoint, client_id=None, client_secret=None, interval=None, max_attempts=None):
+        """
+        Prompts request for device code token at `token_endpoint`. Used by
+        DeviceCodeClient. Will continuously loop and check the device code
+
+        :param token_endpoint: endpoint for retrieving the token code
+        :param interval: Time between attempts to check for approval. By default
+                         will use the interval returned by the first request.
+        :param max_attempts: Number of attempts to check for approval. By
+                            default will be infinite.
+        :return: Token dict
+        """
+
+        if client_id is None:
+            client_id = self._client.client_id
+        log.debug("Client ID: %s", client_id)
+
+
+        device_code_response = self.request(
+            "GET",
+            token_endpoint,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        log.debug("Request body sent:%s", device_code_response.request.body)
+        try:
+            device_code_response.raise_for_status()
+        except HTTPError as e:
+            log.debug("Failed to authorize:")
+            log.debug("Device code response status: %s", device_code_response.status_code)
+            log.debug("Device code response content: %s", device_code_response.text)
+            raise e
+
+        device_data = device_code_response.json()
+
+        device_code = device_data["device_code"]
+        user_code = device_data["user_code"]
+        verification_uri = device_data["verification_uri"]
+        log.debug("Device code response data: %s", device_data)
+        print(f"Go to: {verification_uri}")
+        print(f"Enter code: {user_code}")
+
+        access_token = None
+        poll_interval = interval or device_data.get("interval", 15)
+        attempts = 0
+        while access_token is None:
+            if max_attempts is not None and attempts >= max_attempts:
+                raise TimeoutError(
+                    "Device code was not authorized within %d attempts."
+                    % max_attempts
+                )
+            attempts += 1
+            time.sleep(poll_interval)
+
+            try:
+                log.debug("Polling token endpoint %s for device code.", token_endpoint)
+                token = self.fetch_token(
+                    token_endpoint,
+                    method="GET",
+                    device_code=device_code,
+                    include_client_id=True,
+                    scope=self.scope,
+                    data={
+                        "code": device_code,
+                        "device_code": device_code,
+                    }
+                )
+                print(token)
+                print("token response:", token)
+                access_token = token["access_token"]
+                print("Access token obtained:", access_token)
+            except CustomOAuth2Error as e:
+                if "authorization_pending" in str(e):
+                    print(e.description)
+                    continue
+                elif "slow_down" in str(e):
+                    print(f"We're too fast, trying again in {poll_interval}s")
+                    continue
+                else:
+                    raise e
+
+        log.debug("Device code authorized, obtained token %s.", token)
+        return token
+
     def refresh_token(
         self,
         token_url,

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -434,9 +434,7 @@ class OAuth2Session(requests.Session):
         """
 
         if client_id is None:
-            client_id = self._client.client_id
-        log.debug("Client ID: %s", client_id)
-
+            client_id = self.client_id
 
         device_code_response = self.request(
             "GET",
@@ -444,7 +442,11 @@ class OAuth2Session(requests.Session):
             client_id=client_id,
             client_secret=client_secret,
         )
-        log.debug("Request body sent:%s", device_code_response.request.body)
+        log.debug(
+            "Request questing device code from %s with client id %s",
+            token_endpoint,
+            client_id
+        )
         try:
             device_code_response.raise_for_status()
         except HTTPError as e:
@@ -462,17 +464,19 @@ class OAuth2Session(requests.Session):
         print(f"Go to: {verification_uri}")
         print(f"Enter code: {user_code}")
 
-        access_token = None
-        poll_interval = interval or device_data.get("interval", 15)
+        token = None
+        if interval is None:
+            # Fallback to 15s if no interval given anywhere
+            interval = device_data.get("interval", 15)
         attempts = 0
-        while access_token is None:
+        while token is None:
             if max_attempts is not None and attempts >= max_attempts:
                 raise TimeoutError(
                     "Device code was not authorized within %d attempts."
                     % max_attempts
                 )
             attempts += 1
-            time.sleep(poll_interval)
+            time.sleep(interval)
 
             try:
                 log.debug("Polling token endpoint %s for device code.", token_endpoint)
@@ -487,21 +491,17 @@ class OAuth2Session(requests.Session):
                         "device_code": device_code,
                     }
                 )
-                print(token)
-                print("token response:", token)
-                access_token = token["access_token"]
-                print("Access token obtained:", access_token)
             except CustomOAuth2Error as e:
                 if "authorization_pending" in str(e):
                     print(e.description)
                     continue
                 elif "slow_down" in str(e):
-                    print(f"We're too fast, trying again in {poll_interval}s")
+                    interval+=5
+                    print(f"Polling too fast, trying again in {interval}s")
                     continue
                 else:
                     raise e
 
-        log.debug("Device code authorized, obtained token %s.", token)
         return token
 
     def refresh_token(

--- a/requests_oauthlib/oauth2_session.py
+++ b/requests_oauthlib/oauth2_session.py
@@ -4,9 +4,9 @@ from oauthlib.common import generate_token, urldecode
 from oauthlib.oauth2 import WebApplicationClient, InsecureTransportError
 from oauthlib.oauth2 import LegacyApplicationClient
 from oauthlib.oauth2 import TokenExpiredError, is_secure_transport
-import requests
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
-from requests import HTTPError
+
+import requests
 
 log = logging.getLogger(__name__)
 
@@ -460,7 +460,7 @@ class OAuth2Session(requests.Session):
         )
         try:
             device_code_response.raise_for_status()
-        except HTTPError as e:
+        except requests.exceptions.HTTPError as e:
             log.debug("Failed to authorize:")
             log.debug("Device code response status: %s", device_code_response.status_code)
             log.debug("Device code response content: %s", device_code_response.text)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -58,6 +58,8 @@ class OAuth2SessionTest(TestCase):
             self.client_BackendApplication,
         ]
         self.all_clients = self.clients + [self.client_MobileApplication]
+        self.token_endpoint = "https://example.com/token"
+
 
     def test_add_token(self):
         token = "Bearer " + self.token["access_token"]
@@ -220,7 +222,7 @@ class OAuth2SessionTest(TestCase):
 
     @mock.patch("time.time", new=lambda: fake_time)
     def test_fetch_token(self):
-        url = "https://example.com/token"
+        url = self.token_endpoint
 
         for client in self.clients:
             sess = OAuth2Session(client=client, token=self.token)
@@ -405,7 +407,7 @@ class OAuth2SessionTest(TestCase):
         now = time.time()
         self.token["expires_at"] = past
         new_token["expires_at"] = now + 3600
-        url = "https://example.com/token"
+        url = self.token_endpoint
 
         with mock.patch("time.time", lambda: now):
             for client in self.clients:
@@ -502,7 +504,7 @@ class OAuth2SessionTest(TestCase):
 
             return fake_send
 
-        url = "https://example.com/token"
+        url = self.token_endpoint
 
         for client in self.clients:
             sess = OAuth2Session(client=client)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -19,7 +19,6 @@ from oauthlib.oauth2 import DeviceClient
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests_oauthlib import OAuth2Session, TokenUpdated
 import requests
-from requests import HTTPError
 
 from requests.auth import _basic_auth_str
 
@@ -676,11 +675,11 @@ class OAuth2SessionTest(TestCase):
     def test_device_code_http_error_raised(self):
         sess = OAuth2Session(client=DeviceClient(self.client_id))
         sess.request = mock.Mock(
-            side_effect=HTTPError("Something Bad")
+            side_effect=requests.HTTPError("Something Bad")
         )
         with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
             self.assertRaises(
-                HTTPError, asyncio.run, sess.token_from_device_code(self.token_endpoint)
+                requests.HTTPError, asyncio.run, sess.token_from_device_code(self.token_endpoint)
             )
 
 

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -36,11 +36,12 @@ def fake_token(token):
 
     return fake_send
 
-def fake_device_code_response(interval=None):
+def fake_device_code_response(interval=None, expiry=300):
     device_code_data = {
             "device_code": "devicecode123",
             "user_code": "USER-CODE",
             "verification_uri": "https://example.com/verify",
+            "expires_in": expiry,
         }
     if interval is not None:
         device_code_data["interval"] = interval
@@ -48,14 +49,7 @@ def fake_device_code_response(interval=None):
     device_code_resp = requests.Response()
     device_code_resp.status_code = 200
     device_code_resp.headers["Content-Type"] = "application/json"
-    device_code_resp._content = json.dumps(
-        {
-            "device_code": "devicecode123",
-            "user_code": "USER-CODE",
-            "verification_uri": "https://example.com/verify",
-            "interval": 5,
-        }
-    ).encode("utf-8")
+    device_code_resp._content = json.dumps(device_code_data).encode("utf-8")
     return device_code_resp
 
 class OAuth2SessionTest(TestCase):
@@ -646,22 +640,18 @@ class OAuth2SessionTest(TestCase):
         self.assertEqual(ctx.exception.error, "other")
         sess.fetch_token.assert_called_once()
 
-    def test_device_code_max_poll_attempts_raises_timeout_error(self):
+    def test_device_code_expiry_error(self):
         sess = OAuth2Session(client=DeviceClient(self.client_id))
-        sess.fetch_token = mock.Mock(
-            side_effect=CustomOAuth2Error(
-                error="authorization_pending", description="still waiting"
-            )
-        )
-        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        sess.fetch_token = mock.Mock(return_value=self.token)
+        # Expiry 0 to force timeout
+        mock_device_code_resp = fake_device_code_response(15, expiry=0)
+        sess.request = mock.Mock(return_value=mock_device_code_resp)
         with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
             self.assertRaises(
                 TimeoutError,
                 asyncio.run,
-                sess.token_from_device_code(self.token_endpoint, max_poll_attempts=2),
+                sess.token_from_device_code(self.token_endpoint),
             )
-        self.assertEqual(sess.fetch_token.call_count, 2)
-
 
     def test_device_code_explicit_interval(self):
         sess = OAuth2Session(client=DeviceClient(self.client_id))

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -602,7 +602,8 @@ class OAuth2SessionTest(TestCase):
                 self.token,
             ]
         )
-        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        # Interval will default to 5
+        sess.request = mock.Mock(return_value=fake_device_code_response())
         with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
             result = asyncio.run(sess.token_from_device_code(self.token_endpoint))
             self.assertEqual(result, self.token)
@@ -618,7 +619,8 @@ class OAuth2SessionTest(TestCase):
                 self.token,
             ]
         )
-        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        # Interval will default to 5
+        sess.request = mock.Mock(return_value=fake_device_code_response())
         with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
             result = asyncio.run(sess.token_from_device_code(self.token_endpoint))
             self.assertEqual(result, self.token)

--- a/tests/test_oauth2_session.py
+++ b/tests/test_oauth2_session.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import time
 import tempfile
@@ -14,8 +15,11 @@ from oauthlib.oauth2 import TokenExpiredError, OAuth2Error
 from oauthlib.oauth2 import MismatchingStateError
 from oauthlib.oauth2 import WebApplicationClient, MobileApplicationClient
 from oauthlib.oauth2 import LegacyApplicationClient, BackendApplicationClient
+from oauthlib.oauth2 import DeviceClient
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests_oauthlib import OAuth2Session, TokenUpdated
 import requests
+from requests import HTTPError
 
 from requests.auth import _basic_auth_str
 
@@ -32,6 +36,27 @@ def fake_token(token):
 
     return fake_send
 
+def fake_device_code_response(interval=None):
+    device_code_data = {
+            "device_code": "devicecode123",
+            "user_code": "USER-CODE",
+            "verification_uri": "https://example.com/verify",
+        }
+    if interval is not None:
+        device_code_data["interval"] = interval
+
+    device_code_resp = requests.Response()
+    device_code_resp.status_code = 200
+    device_code_resp.headers["Content-Type"] = "application/json"
+    device_code_resp._content = json.dumps(
+        {
+            "device_code": "devicecode123",
+            "user_code": "USER-CODE",
+            "verification_uri": "https://example.com/verify",
+            "interval": 5,
+        }
+    ).encode("utf-8")
+    return device_code_resp
 
 class OAuth2SessionTest(TestCase):
     def setUp(self):
@@ -525,6 +550,146 @@ class OAuth2SessionTest(TestCase):
             else:
                 sess.fetch_token(url)
             self.assertTrue(sess.authorized)
+    
+    def test_device_code_client_id_defaults_to_session_client_id(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(return_value=self.token)
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
+            asyncio.run(sess.token_from_device_code(self.token_endpoint))
+            sess.request.assert_called_once_with(
+                "GET", self.token_endpoint, client_id=self.client_id, client_secret=None
+            )
+            sess.fetch_token.assert_called_once_with(
+                self.token_endpoint,
+                method="GET",
+                device_code="devicecode123",
+                include_client_id=True,
+                scope=sess.scope,
+                client_id=self.client_id,
+                client_secret=None
+            )
+
+    def test_explicit_client_id_and_secret_are_used(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(return_value=self.token)
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
+            asyncio.run(
+                sess.token_from_device_code(
+                    self.token_endpoint,
+                    client_id="explicit-id",
+                    client_secret="explicit-secret",
+                )
+            )
+            sess.request.assert_called_once_with(
+                "GET",
+                self.token_endpoint,
+                client_id="explicit-id",
+                client_secret="explicit-secret",
+            )
+            sess.fetch_token.assert_called_once_with(
+                self.token_endpoint,
+                method="GET",
+                device_code="devicecode123",
+                include_client_id=True,
+                scope=sess.scope,
+                client_id="explicit-id",
+                client_secret="explicit-secret",
+            )
+
+    def test_device_code_authorization_pending_retries_then_succeeds(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(
+            side_effect=[
+                CustomOAuth2Error(
+                    error="authorization_pending", description="still waiting"
+                ),
+                self.token,
+            ]
+        )
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
+            result = asyncio.run(sess.token_from_device_code(self.token_endpoint))
+            self.assertEqual(result, self.token)
+            self.assertEqual(sess.fetch_token.call_count, 2)
+            # Interval remains the same between sleep calls
+            mock_sleep.assert_has_calls([mock.call(5), mock.call(5)])
+
+    def test_device_code_slow_down_increases_interval_then_succeeds(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(
+            side_effect=[
+                CustomOAuth2Error(error="slow_down", description="too fast"),
+                self.token,
+            ]
+        )
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
+            result = asyncio.run(sess.token_from_device_code(self.token_endpoint))
+            self.assertEqual(result, self.token)
+            self.assertEqual(sess.fetch_token.call_count, 2)
+            # Interval increases between sleep calls as requested
+            mock_sleep.assert_has_calls([mock.call(5), mock.call(10)])
+    
+    def test_device_code_raises_other_oauth_error(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.request = mock.Mock(return_value=fake_device_code_response())
+        sess.fetch_token = mock.Mock(
+            side_effect= CustomOAuth2Error(
+                    error="other", description="function should raise this"
+                )
+        )
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
+            with self.assertRaises(CustomOAuth2Error) as ctx:
+                asyncio.run(sess.token_from_device_code(self.token_endpoint))
+        self.assertEqual(ctx.exception.error, "other")
+        sess.fetch_token.assert_called_once()
+
+    def test_device_code_max_poll_attempts_raises_timeout_error(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(
+            side_effect=CustomOAuth2Error(
+                error="authorization_pending", description="still waiting"
+            )
+        )
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
+            self.assertRaises(
+                TimeoutError,
+                asyncio.run,
+                sess.token_from_device_code(self.token_endpoint, max_poll_attempts=2),
+            )
+        self.assertEqual(sess.fetch_token.call_count, 2)
+
+
+    def test_device_code_explicit_interval(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(return_value=self.token)
+        sess.request = mock.Mock(return_value=fake_device_code_response(15))
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
+            asyncio.run(
+                sess.token_from_device_code(self.token_endpoint, interval=1)
+            )
+            mock_sleep.assert_called_once_with(1)
+
+    def test_device_code_default_interval(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.fetch_token = mock.Mock(return_value=self.token)
+        sess.request = mock.Mock(return_value=fake_device_code_response())
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep") as mock_sleep:
+            asyncio.run(sess.token_from_device_code(self.token_endpoint))
+            mock_sleep.assert_called_once_with(5)
+
+    def test_device_code_http_error_raised(self):
+        sess = OAuth2Session(client=DeviceClient(self.client_id))
+        sess.request = mock.Mock(
+            side_effect=HTTPError("Something Bad")
+        )
+        with mock.patch("requests_oauthlib.oauth2_session.time.sleep"):
+            self.assertRaises(
+                HTTPError, asyncio.run, sess.token_from_device_code(self.token_endpoint)
+            )
 
 
 class OAuth2SessionNetrcTest(OAuth2SessionTest):


### PR DESCRIPTION
Adds support for OAuth2.0 device code authorization flow as per [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) by adding the async function `Oauth2Session.token_from_device_code`. For a given device authorization endpoint, this function can be called with options for explicit interval polling time. 

Process:
1. Retrieve the initial device code response
2. Print returned `verification_uri` and user_code to stdout
3. If device code expires raise a `TimeoutError`

Also makes changes to tests in `Oauth2SessionTest`: set `self.token_endpoint = "https://example.com/token"` as it was often repeated between tests. 
